### PR TITLE
Update schema to remove mim from disease table

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/models.py
+++ b/gene2phenotype_project/gene2phenotype_app/models.py
@@ -72,8 +72,7 @@ class LocusGenotypeDisease(models.Model):
         indexes = [
             models.Index(fields=['locus']),
             models.Index(fields=['disease']),
-            models.Index(fields=['confidence']),
-            models.Index(fields=['is_deleted'])
+            models.Index(fields=['confidence'])
         ]
 
 class LGDCrossCuttingModifier(models.Model):
@@ -376,7 +375,7 @@ class DiseasePublication(models.Model):
     publication = models.ForeignKey("Publication", on_delete=models.PROTECT)
     families = models.IntegerField(null=True)
     consanguinity = models.ForeignKey("Attrib", related_name='consanguinity', on_delete=models.PROTECT, null=True)
-    ethnicity = models.ForeignKey("Attrib", related_name='ethnicity', on_delete=models.PROTECT, null=True)
+    affected_individuals = models.IntegerField(null=True)
     is_deleted = models.SmallIntegerField(null=False, default=False)
     history = HistoricalRecords()
 
@@ -454,7 +453,7 @@ class PublicationFamilies(models.Model):
     publication = models.ForeignKey("Publication", on_delete=models.PROTECT)
     families = models.IntegerField(null=False)
     consanguinity = models.ForeignKey("Attrib", related_name='consanguinity_publication', on_delete=models.PROTECT, null=True)
-    ethnicity = models.ForeignKey("Attrib", related_name='ethnicity_publication', on_delete=models.PROTECT, null=True)
+    affected_individuals = models.IntegerField(null=True)
     ancestries = models.CharField(max_length=500, null=True)
     is_deleted = models.SmallIntegerField(null=False, default=False)
     history = HistoricalRecords()
@@ -464,7 +463,7 @@ class PublicationFamilies(models.Model):
         indexes = [
             models.Index(fields=["publication"])
         ]
-        unique_together = ["publication", "families", "consanguinity", "ethnicity"]
+        unique_together = ["publication", "families", "consanguinity", "affected_individuals"]
 
 class PublicationComment(models.Model):
     id = models.AutoField(primary_key=True)

--- a/gene2phenotype_project/gene2phenotype_app/models.py
+++ b/gene2phenotype_project/gene2phenotype_app/models.py
@@ -72,7 +72,8 @@ class LocusGenotypeDisease(models.Model):
         indexes = [
             models.Index(fields=['locus']),
             models.Index(fields=['disease']),
-            models.Index(fields=['confidence'])
+            models.Index(fields=['confidence']),
+            models.Index(fields=['is_deleted'])
         ]
 
 class LGDCrossCuttingModifier(models.Model):
@@ -323,6 +324,12 @@ class AttribType(models.Model):
         db_table = "attrib_type"
 
 class OntologyTerm(models.Model):
+    """
+        Ontology term can be of different types:
+            - disease (Mondo, OMIM)
+            - phenotype (HPO)
+            - variant type (SO)
+    """
     id = models.AutoField(primary_key=True)
     accession = models.CharField(max_length=255, null=False, unique=True)
     term = models.CharField(max_length=255, null=False, unique=True)
@@ -342,7 +349,6 @@ class OntologyTerm(models.Model):
 class Disease(models.Model):
     id = models.AutoField(primary_key=True)
     name = models.CharField(max_length=255, unique=True, null=False)
-    mim = models.IntegerField(null=True)
     history = HistoricalRecords()
 
     class Meta:
@@ -361,6 +367,9 @@ class DiseaseSynonym(models.Model):
     class Meta:
         db_table = "disease_synonym"
         unique_together = ['disease', 'synonym']
+        indexes = [
+            models.Index(fields=['synonym'])
+        ]
 
 class DiseasePublication(models.Model):
     disease = models.ForeignKey("Disease", on_delete=models.PROTECT)

--- a/gene2phenotype_project/gene2phenotype_app/serializers.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers.py
@@ -857,8 +857,7 @@ class CreateDiseaseSerializer(serializers.ModelSerializer):
                         source = get_ontology_source(ontology_accession)
 
                         if source is None:
-                            raise serializers.ValidationError({"message": f"invalid id {ontology_accession}
-                                                                please input an id from OMIM or Mondo"})
+                            raise serializers.ValidationError({"message": f"invalid id {ontology_accession} please input an id from OMIM or Mondo"})
 
                         elif source == "Mondo":
                             # Check if ontology accession is valid
@@ -878,13 +877,11 @@ class CreateDiseaseSerializer(serializers.ModelSerializer):
 
                         elif source == "OMIM":
                             omim_disease = get_ontology(ontology_accession, source)
-                            if omim_disease is None:
-                                raise serializers.ValidationError({"message": "invalid omim id",
-                                                                   "please check id": ontology_accession})
-                            elif omim_disease == "query failed":
+                            # TODO: check if we can use the OMIM API in the future
+                            if omim_disease == "query failed":
                                 raise serializers.ValidationError({"message": f"cannot query omim id {ontology_accession}"})
 
-                            if ontology_desc is None and len(omim_disease['description']) > 0:
+                            if ontology_desc is None and omim_disease is not None and len(omim_disease['description']) > 0:
                                 ontology_desc = omim_disease['description'][0]
 
                         source = Source.objects.get(name=source)

--- a/gene2phenotype_project/gene2phenotype_app/serializers.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers.py
@@ -866,6 +866,8 @@ class CreateDiseaseSerializer(serializers.ModelSerializer):
                             if mondo_disease is None:
                                 raise serializers.ValidationError({"message": "invalid mondo id",
                                                                    "please check id": ontology_accession})
+                            elif mondo_disease == "query failed":
+                                raise serializers.ValidationError({"message": f"cannot query mondo id {ontology_accession}"})
 
                             # Replace '_' from mondo ID
                             ontology_accession = re.sub(r'\_', ':', ontology_accession)
@@ -879,6 +881,8 @@ class CreateDiseaseSerializer(serializers.ModelSerializer):
                             if omim_disease is None:
                                 raise serializers.ValidationError({"message": "invalid omim id",
                                                                    "please check id": ontology_accession})
+                            elif omim_disease == "query failed":
+                                raise serializers.ValidationError({"message": f"cannot query omim id {ontology_accession}"})
 
                             if ontology_desc is None and len(omim_disease['description']) > 0:
                                 ontology_desc = omim_disease['description'][0]

--- a/gene2phenotype_project/gene2phenotype_app/utils/__init__.py
+++ b/gene2phenotype_project/gene2phenotype_app/utils/__init__.py
@@ -1,4 +1,4 @@
-from .disease_utils import clean_string, get_mondo, clean_omim_disease, get_ontology_source
+from .disease_utils import clean_string, get_ontology, clean_omim_disease, get_ontology_source
 from .publication_utils import get_publication, get_authors
 from .locus_utils import validate_gene
 from .phenotype_utils import validate_phenotype

--- a/gene2phenotype_project/gene2phenotype_app/utils/__init__.py
+++ b/gene2phenotype_project/gene2phenotype_app/utils/__init__.py
@@ -1,4 +1,4 @@
-from .disease_utils import clean_string, get_mondo, clean_omim_disease
+from .disease_utils import clean_string, get_mondo, clean_omim_disease, get_ontology_source
 from .publication_utils import get_publication, get_authors
 from .locus_utils import validate_gene
 from .phenotype_utils import validate_phenotype

--- a/gene2phenotype_project/gene2phenotype_app/utils/disease_utils.py
+++ b/gene2phenotype_project/gene2phenotype_app/utils/disease_utils.py
@@ -76,8 +76,26 @@ def clean_omim_disease(name):
 
     return disease_name.lower().strip()
 
-def get_mondo(id):
-    url = f"https://www.ebi.ac.uk/ols4/api/search?q={id}&ontology=mondo&exact=1"
+
+"""
+    Get the ontology info from the disease ID
+
+    Input:
+            id: disease ID
+            source: source name
+    Output:
+            ols response
+            return None if no response or source is invalid
+"""
+def get_ontology(id, source):
+    if source.lower() == "mondo":
+        url = f"https://www.ebi.ac.uk/ols4/api/search?q={id}&ontology=mondo&exact=1"
+
+    elif source.lower() == "omim":
+        url = f"https://www.ebi.ac.uk/ols4/api/search?q={id}&ontology=cco"
+
+    else:
+        return None
 
     r = requests.get(url, headers={ "Content-Type" : "application/json"})
 
@@ -94,9 +112,14 @@ def get_mondo(id):
 
     return name
 
+
 """
+    To store the ontology ID/term we have to know its source.
+    The source can be OMIM or Mondo.
+
     Input: disease ID
     Output: source of the disease ID (Mondo or OMIM)
+            the source name is going to be used to fetch the source id from the db (case sensitive)
 """
 def get_ontology_source(id):
     source = None
@@ -104,6 +127,6 @@ def get_ontology_source(id):
     if id.startswith("MONDO"):
         source = "Mondo"
     elif id.isdigit():
-        source = 'OMIM'
+        source = "OMIM"
 
     return source

--- a/gene2phenotype_project/gene2phenotype_app/utils/disease_utils.py
+++ b/gene2phenotype_project/gene2phenotype_app/utils/disease_utils.py
@@ -101,7 +101,7 @@ def get_ontology(id, source):
 
     if not r.ok:
         r.raise_for_status()
-        sys.exit()
+        return "query failed"
 
     decoded = r.json()
 

--- a/gene2phenotype_project/gene2phenotype_app/utils/disease_utils.py
+++ b/gene2phenotype_project/gene2phenotype_app/utils/disease_utils.py
@@ -93,3 +93,17 @@ def get_mondo(id):
         name = None
 
     return name
+
+"""
+    Input: disease ID
+    Output: source of the disease ID (Mondo or OMIM)
+"""
+def get_ontology_source(id):
+    source = None
+
+    if id.startswith("MONDO"):
+        source = "Mondo"
+    elif id.isdigit():
+        source = 'OMIM'
+
+    return source


### PR DESCRIPTION
OMIM IDs should be stored in table ontology_term and linked to the disease in table disease_ontology.
This PR removes the column 'mim' from disease and adds the necessary updates to the API to accept/save OMIM IDs in the correct table.