### PR TITLE
To allow for publish

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/views/curation.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/curation.py
@@ -55,7 +55,7 @@ class AddCurationData(BaseAdd):
 
         if serializer.is_valid():
             instance = serializer.save()
-            return Response({"message": f"Data saved successfully for session name '{instance.session_name}'"}, status=status.HTTP_200_OK)
+            return Response({"message": f"Data saved successfully for session name '{instance.session_name}'", "result": f"{instance.stable_id.stable_id}"}, status=status.HTTP_200_OK)
         else:
             return Response({"errors": serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
 


### PR DESCRIPTION
Just a quick fix for save and publishing, the stableid is part of the JSONResponse because thats how the stableID is retrieved for publish when it has been saved.