### PR TITLE
Fix endpoints that return a summary of records

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/serializers/disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/disease.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from django.db.models import Q
 import re
 
 from ..models import (Disease, DiseaseOntologyTerm, DiseaseSynonym,
@@ -79,7 +80,9 @@ class DiseaseDetailSerializer(DiseaseSerializer):
     def records_summary(self, id, user):
         """
             Returns a summary of the LGD records associated with the disease.
-            TODO: check refuted and disputed records
+            If the user is non-authenticated:
+                - it does not return refuted and disputed records
+                - only returns records linked to visible panels
         """
         # TODO: improve query, this can be done in a single query
         lgd_list = LocusGenotypeDisease.objects.filter(disease=id, is_deleted=0)
@@ -92,7 +95,9 @@ class DiseaseDetailSerializer(DiseaseSerializer):
         else:
             lgd_select = lgd_list.select_related('disease', 'genotype', 'confidence'
                                                ).prefetch_related('lgd_panel', 'panel', 'lgd_variant_gencc_consequence', 'lgd_variant_type', 'lgd_molecular_mechanism', 'g2pstable_id'
-                                                                  ).order_by('-date_review').filter(lgdpanel__panel__is_visible=1)
+                                                                  ).order_by('-date_review').filter(Q(lgdpanel__panel__is_visible=1) &
+                                                                                                    ~Q(confidence__value='disputed') &
+                                                                                                    ~Q(confidence__value='refuted'))
 
         lgd_objects_list = list(lgd_select.values('disease__name',
                                                   'lgdpanel__panel__name',

--- a/gene2phenotype_project/gene2phenotype_app/serializers/disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/disease.py
@@ -93,11 +93,15 @@ class DiseaseDetailSerializer(DiseaseSerializer):
                                                                   ).order_by('-date_review')
 
         else:
-            lgd_select = lgd_list.select_related('disease', 'genotype', 'confidence'
+            filters = (
+                Q(lgdpanel__panel__is_visible=1) &
+                ~Q(confidence__value='disputed') &
+                ~Q(confidence__value='refuted')
+            )
+
+            lgd_select = lgd_list.filter(filters).select_related('disease', 'genotype', 'confidence'
                                                ).prefetch_related('lgd_panel', 'panel', 'lgd_variant_gencc_consequence', 'lgd_variant_type', 'lgd_molecular_mechanism', 'g2pstable_id'
-                                                                  ).order_by('-date_review').filter(Q(lgdpanel__panel__is_visible=1) &
-                                                                                                    ~Q(confidence__value='disputed') &
-                                                                                                    ~Q(confidence__value='refuted'))
+                                                                  ).order_by('-date_review')
 
         lgd_objects_list = list(lgd_select.values('disease__name',
                                                   'lgdpanel__panel__name',

--- a/gene2phenotype_project/gene2phenotype_app/serializers/locus.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/locus.py
@@ -101,11 +101,15 @@ class LocusGeneSerializer(LocusSerializer):
                                                                   ).order_by('-date_review')
 
         else:
-            lgd_select = lgd_list.select_related('disease', 'genotype', 'confidence'
+            filters = (
+                Q(lgdpanel__panel__is_visible=1) &
+                ~Q(confidence__value='disputed') &
+                ~Q(confidence__value='refuted')
+            )
+
+            lgd_select = lgd_list.filter(filters).select_related('disease', 'genotype', 'confidence'
                                                ).prefetch_related('lgd_panel', 'panel', 'lgd_variant_gencc_consequence', 'lgd_variant_type', 'lgd_molecular_mechanism'
-                                                                  ).order_by('-date_review').filter(Q(lgdpanel__panel__is_visible=1) &
-                                                                                                    ~Q(confidence__value='disputed') &
-                                                                                                    ~Q(confidence__value='refuted'))
+                                                                  ).order_by('-date_review')
 
         lgd_objects_list = list(lgd_select.values('disease__name',
                                                   'lgdpanel__panel__name',

--- a/gene2phenotype_project/gene2phenotype_app/serializers/panel.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/panel.py
@@ -121,7 +121,14 @@ class PanelDetailSerializer(serializers.ModelSerializer):
                                                         'lgd__lgd_molecular_mechanism'
                                                     ).order_by('-lgd__date_review').filter(lgd__is_deleted=0)
         else:
-            lgd_panels_selected = lgd_panels.select_related('lgd',
+            filters = (
+                Q(lgd__is_deleted=0) &
+                Q(panel__is_visible=1) &
+                ~Q(lgd__confidence__value='disputed') &
+                ~Q(lgd__confidence__value='refuted')
+            )
+
+            lgd_panels_selected = lgd_panels.filter(filters).select_related('lgd',
                                                         'lgd__locus',
                                                         'lgd__disease',
                                                         'lgd__genotype',
@@ -130,10 +137,7 @@ class PanelDetailSerializer(serializers.ModelSerializer):
                                                         'lgd__lgd_variant_gencc_consequence',
                                                         'lgd__lgd_variant_type',
                                                         'lgd__lgd_molecular_mechanism'
-                                                    ).order_by('-lgd__date_review').filter(Q(lgd__is_deleted=0) &
-                                                                                           Q(panel__is_visible=1) &
-                                                                                           ~Q(lgd__confidence__value='disputed') &
-                                                                                           ~Q(lgd__confidence__value='refuted'))
+                                                    ).order_by('-lgd__date_review')
 
         lgd_objects_list = list(lgd_panels_selected.values('lgd__locus__name',
                                                            'lgd__disease__name',

--- a/gene2phenotype_project/gene2phenotype_app/views/panel.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/panel.py
@@ -120,7 +120,7 @@ class PanelRecordsSummary(BaseView):
 
         if flag == 1:
             serializer = PanelDetailSerializer()
-            summary = serializer.records_summary(queryset.first())
+            summary = serializer.records_summary(queryset.first(), self.request.user)
             response_data = {
                 'panel_name': queryset.first().name,
                 'records_summary': summary,


### PR DESCRIPTION
Test the following endpoints (without login)

- https://wwwdev.ebi.ac.uk/gene2phenotype/api/disease/CDH1-related%20prostate%20cancer%20test%2057/summary/
The disease summary returns refuted records even though I am not logged in -> incorrect

- https://wwwdev.ebi.ac.uk/gene2phenotype/api/lgd/G2P03879/
The LGD page does not allow non-authenticated users to access a refuted record -> correct