### PR TITLE
Update date_review after LGD updates

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
@@ -439,6 +439,9 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
         if(is_reviewed is not None and (is_reviewed == 1 or is_reviewed == 0)):
             instance.is_reviewed = is_reviewed
 
+        # Update the 'date_review'
+        instance.date_review = datetime.now()
+
         # Save all updates
         instance.save()
 

--- a/gene2phenotype_project/gene2phenotype_app/serializers/panel.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/panel.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from django.db.models import Q
+from datetime import datetime
 
 from ..models import Panel, User, UserPanel, LGDPanel, Attrib
 
@@ -244,6 +245,10 @@ class LGDPanelSerializer(serializers.ModelSerializer):
                 lgd_panel_obj.is_deleted = 0
                 lgd_panel_obj.save()
         
+        # Update the 'date_review' of the LocusGenotypeDisease obj
+        lgd.date_review = datetime.now()
+        lgd.save()
+
         return lgd_panel_obj
 
     class Meta:


### PR DESCRIPTION
After an update to the Locus Genotype Disease obj, we have to ensure the 'date_review' reflects the date of the latest update. 

This PR updates the 'date_review' after updating a G2P record (LGD).
The update affects the following endpoints:
```
gene2phenotype/api/lgd/<str:stable_id>/update_confidence/
gene2phenotype/api/lgd/<str:stable_id>/panel/
```