### PR TITLE
Add endpoint to update molecular mechanism

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/serializers/__init__.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/__init__.py
@@ -19,7 +19,8 @@ from .locus_genotype_disease import (LocusGenotypeDiseaseSerializer, LGDCommentS
                                      LGDVariantConsequenceListSerializer, LGDVariantGenCCConsequenceSerializer,
                                      LGDCrossCuttingModifierListSerializer, LGDCrossCuttingModifierSerializer,
                                      LGDVariantTypeListSerializer, LGDVariantTypeSerializer,
-                                     LGDVariantTypeDescriptionListSerializer, LGDVariantTypeDescriptionSerializer)
+                                     LGDVariantTypeDescriptionListSerializer, LGDVariantTypeDescriptionSerializer,
+                                     MolecularMechanismSerializer)
 
 from .stable_id import G2PStableIDSerializer
 

--- a/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
@@ -411,7 +411,8 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
         confidence_support = validated_data.get("confidence_support", None)
         is_reviewed = validated_data.get("is_reviewed", None)
 
-        if validated_confidence is not None:
+        if(validated_confidence is not None and isinstance(validated_confidence, dict) 
+           and "value" in validated_confidence):
             confidence = validated_confidence["value"]
         else:
             raise serializers.ValidationError({"error": f"Empty confidence value"})
@@ -472,8 +473,8 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
                             [{'primary_type': 'Rescue', 'secondary_type': ['Human', 'Patient Cells']}]}]
 
         """
-        molecular_mechanism_value = validated_data.get("molecular_mechanism")["name"] # the mechanism value
-        molecular_mechanism_support = validated_data.get("molecular_mechanism")["support"] # the mechanism support (inferred/evidence)
+        molecular_mechanism_value = validated_data["molecular_mechanism"]["name"] # the mechanism value
+        molecular_mechanism_support = validated_data["molecular_mechanism"]["support"] # the mechanism support (inferred/evidence)
         mechanism_synopsis = validated_data.get("mechanism_synopsis", None) # mechanism synopsis is optional
         mechanism_evidence = validated_data.get("mechanism_evidence", None) # molecular mechanism evidence is optional
 

--- a/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
@@ -455,7 +455,8 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
     def update_mechanism(self, lgd_instance, validated_data):
         """
             Method to update the molecular mechanism of the LGD record.
-            It only allows to update mechanisms with value 'undetermined'.
+            It only allows to update mechanisms with value 'undetermined'
+            and evidence 'inferred'.
 
             Mandatory fields are "molecular_mechanism" and "mechanism_evidence".
 
@@ -474,7 +475,7 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
         molecular_mechanism_value = validated_data.get("molecular_mechanism")["name"]
         molecular_mechanism_support = validated_data.get("molecular_mechanism")["support"]
         mechanism_synopsis = validated_data.get("mechanism_synopsis", None) # synopsis is optional
-        mechanism_evidence = validated_data.get("mechanism_evidence")
+        mechanism_evidence = validated_data.get("mechanism_evidence", None) # evidence is optional
 
         try:
             cv_mechanism_obj = CVMolecularMechanism.objects.get(

--- a/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
@@ -458,7 +458,7 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
             It only allows to update mechanisms with value 'undetermined'
             and evidence 'inferred'.
 
-            Mandatory fields are "molecular_mechanism" and "mechanism_evidence".
+            Mandatory fields are molecular_mechanism name and support (inferred/evidence).
 
             Example:    "molecular_mechanism": {
                             "name": "gain of function",
@@ -531,10 +531,14 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
         for evidence in mechanism_evidence:
             pmid = evidence.get("pmid")
 
+            # Check if the PMID exists in G2P
+            # When updating the mechanism the supporting pmid used as evidence
+            # have to already be linked to the LGD record
             try:
                 publication_obj = Publication.objects.get(pmid=pmid)
             except Publication.DoesNotExist:
-                raise serializers.ValidationError({"message": f"Invalid pmid '{pmid}'"})
+                # TODO: improve in future to insert new pmids + link them to the record
+                raise serializers.ValidationError({"message": f"pmid '{pmid}' not found in G2P"})
 
             if evidence.get("description") != "":
                 description = evidence.get("description")

--- a/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
@@ -456,7 +456,7 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
         """
             Method to update the molecular mechanism of the LGD record.
             It only allows to update mechanisms with value 'undetermined'
-            and evidence 'inferred'.
+            and support value 'inferred'.
 
             Mandatory fields are molecular_mechanism name and support (inferred/evidence).
 
@@ -472,10 +472,10 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
                             [{'primary_type': 'Rescue', 'secondary_type': ['Human', 'Patient Cells']}]}]
 
         """
-        molecular_mechanism_value = validated_data.get("molecular_mechanism")["name"]
-        molecular_mechanism_support = validated_data.get("molecular_mechanism")["support"]
-        mechanism_synopsis = validated_data.get("mechanism_synopsis", None) # synopsis is optional
-        mechanism_evidence = validated_data.get("mechanism_evidence", None) # evidence is optional
+        molecular_mechanism_value = validated_data.get("molecular_mechanism")["name"] # the mechanism value
+        molecular_mechanism_support = validated_data.get("molecular_mechanism")["support"] # the mechanism support (inferred/evidence)
+        mechanism_synopsis = validated_data.get("mechanism_synopsis", None) # mechanism synopsis is optional
+        mechanism_evidence = validated_data.get("mechanism_evidence", None) # molecular mechanism evidence is optional
 
         try:
             cv_mechanism_obj = CVMolecularMechanism.objects.get(

--- a/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
@@ -407,9 +407,14 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
         """
         # validated_data example:
         # {'confidence': {'value': 'definitive'}, 'confidence_support': '', 'is_reviewed': None}
-        confidence = validated_data.get("confidence")["value"]
-        confidence_support = validated_data.get("confidence_support")
-        is_reviewed = validated_data.get("is_reviewed")
+        validated_confidence = validated_data.get("confidence", None)
+        confidence_support = validated_data.get("confidence_support", None)
+        is_reviewed = validated_data.get("is_reviewed", None)
+
+        if validated_confidence is not None:
+            confidence = validated_confidence["value"]
+        else:
+            raise serializers.ValidationError({"error": f"Empty confidence value"})
 
         # Get confidence
         try:
@@ -443,6 +448,12 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
         instance.save()
 
         return instance
+
+    def update_mechanism(self, instance, validated_data):
+        mechanism = validated_data.get('mechanism')
+
+        print("Mechanism validated data:", mechanism)
+
 
     class Meta:
         model = LocusGenotypeDisease

--- a/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
@@ -456,6 +456,7 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
         """
             Method to update the molecular mechanism of the LGD record.
             It only allows to update mechanisms with value 'undetermined'.
+
             Mandatory fields are "molecular_mechanism" and "mechanism_evidence".
 
             Example:    "molecular_mechanism": {
@@ -564,7 +565,7 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
                         is_deleted = 0
                     )
 
-        # Save old molecular mechanism to update it later
+        # Save old molecular mechanism to delete it later
         old_mechanism_obj = lgd_instance.molecular_mechanism
 
         # Update LGD record
@@ -572,10 +573,9 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
         lgd_instance.date_review = datetime.now()
         lgd_instance.save()
 
-        # The old molecular mechanism has to be updated to is_deleted = 1
-        # As this method only allows to update 'undetermined' mechanisms, we don't need to 'delete' evidence
-        old_mechanism_obj.is_deleted = 1
-        old_mechanism_obj.save()
+        # The old molecular mechanism can be deleted - the deletion is stored in the history table
+        # As this method only allows to update 'undetermined' mechanisms, there is no evidence to be deleted
+        old_mechanism_obj.delete()
 
         return lgd_instance
 

--- a/gene2phenotype_project/gene2phenotype_app/urls.py
+++ b/gene2phenotype_project/gene2phenotype_app/urls.py
@@ -39,7 +39,7 @@ urlpatterns = [
 
     ### Endpoints to update/add/delete the G2P record (LGD) ###
     path('lgd/<str:stable_id>/update_confidence/', views.LGDUpdateConfidence.as_view(), name="lgd_update_confidence"),
-    # Update molecular mechanism - only allows to update if mechanism is 'undetermined'
+    # Update molecular mechanism - only allows to update if mechanism is 'undetermined' and support is 'inferred'
     path('lgd/<str:stable_id>/update_mechanism/', views.LGDUpdateMechanism.as_view(), name="lgd_update_mechanism"),
     # Add or delete panel from LGD record. Actions: UPDATE (to delete one panel), POST (to add one panel)
     path('lgd/<str:stable_id>/panel/', views.LGDEditPanel.as_view(), name="lgd_panel"),

--- a/gene2phenotype_project/gene2phenotype_app/urls.py
+++ b/gene2phenotype_project/gene2phenotype_app/urls.py
@@ -39,6 +39,8 @@ urlpatterns = [
 
     ### Endpoints to update/add/delete the G2P record (LGD) ###
     path('lgd/<str:stable_id>/update_confidence/', views.LGDUpdateConfidence.as_view(), name="lgd_update_confidence"),
+    # Update molecular mechanism - only allows to update if mechanism is 'undetermined'
+    path('lgd/<str:stable_id>/update_mechanism/', views.LGDUpdateMechanism.as_view(), name="lgd_update_mechanism"),
     # Add or delete panel from LGD record. Actions: UPDATE (to delete one panel), POST (to add one panel)
     path('lgd/<str:stable_id>/panel/', views.LGDEditPanel.as_view(), name="lgd_panel"),
     # Add or delete publication(s) from LGD record. Actions: UPDATE (to delete one publication), POST (to add multiple publications)

--- a/gene2phenotype_project/gene2phenotype_app/views/__init__.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/__init__.py
@@ -23,6 +23,7 @@ from .locus_genotype_disease import (ListMolecularMechanisms, VariantTypesList,
                                      LocusGenotypeDiseaseDetail, LGDEditCCM,
                                      LGDEditComment, LGDEditVariantConsequences,
                                      LGDEditVariantTypes, LGDEditVariantTypeDescriptions,
-                                     LGDUpdateConfidence, LocusGenotypeDiseaseDelete)
+                                     LGDUpdateConfidence, LocusGenotypeDiseaseDelete,
+                                     LGDUpdateMechanism)
 
 from .phenotype import AddPhenotype, PhenotypeDetail, LGDEditPhenotypes, LGDEditPhenotypeSummary

--- a/gene2phenotype_project/gene2phenotype_app/views/base.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/base.py
@@ -1,11 +1,15 @@
 from rest_framework import generics, status
+from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from rest_framework.response import Response
 from django.db import transaction
 from django.urls import get_resolver
 from rest_framework.decorators import api_view
-from gene2phenotype_app.models import User
+
 import re
+
+from gene2phenotype_app.models import User
+
 
 
 class BaseView(generics.ListAPIView):
@@ -48,6 +52,12 @@ class BaseUpdate(generics.UpdateAPIView):
             raise Http404(f"{data}")
         else:
             raise Http404(f"Could not find '{data}' for ID '{stable_id}'")
+    
+    def handle_no_update(self, data, stable_id):
+        if data is None:
+            raise Http404(f"{data}")
+        else:
+            raise PermissionDenied(f"Cannot update '{data}' for ID '{stable_id}'")
 
 
 @api_view(['GET'])

--- a/gene2phenotype_project/gene2phenotype_app/views/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/locus_genotype_disease.py
@@ -250,9 +250,8 @@ class LGDUpdateMechanism(BaseUpdate):
         else:
             # Only 'undetermined' mechanisms can be updated
             lgd_obj = queryset.first()
-            if lgd_obj.molecular_mechanism.mechanism.value != "undetermined":
-                self.handle_no_update('molecular mechanism', stable_id)
-            elif lgd_obj.molecular_mechanism.mechanism_support.value != "inferred":
+            if not (lgd_obj.molecular_mechanism.mechanism.value == "undetermined" 
+                    and lgd_obj.molecular_mechanism.mechanism_support.value == "inferred"):
                 self.handle_no_update('molecular mechanism', stable_id)
 
             return queryset

--- a/gene2phenotype_project/gene2phenotype_app/views/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/locus_genotype_disease.py
@@ -354,7 +354,7 @@ class LGDUpdateMechanism(BaseUpdate):
             serializer.update_mechanism(lgd_obj, mechanism_data)
         except Exception as e:
             return Response(
-                {"error": f"Problem updating molecular mechanism"},
+                {"error": f"Error while updating molecular mechanism"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )
         else:


### PR DESCRIPTION
Ticket: [G2P-182](https://www.ebi.ac.uk/panda/jira/browse/G2P-182)
We only allow updates if the mechanism is 'undetermined'.

**New endpoint**
`gene2phenotype/api/lgd/<str:stable_id>/update_mechanism/`

The input data has the same format as the mechanism data sent by the curation page.

**To test** 
db: dlemos_G2P_2024_18
Input data:
```
{
    "molecular_mechanism": {
				"name": "gain of function",
				"support": "evidence"
		    },
    "mechanism_synopsis": {
				"name": "",
				"support": ""
		    },
    "mechanism_evidence": [
        {
						"pmid": "18247425",
						"description": "This is description for the mechanism evidence.",
						"evidence_types": [
								{
										"primary_type": "Function",
										"secondary_type": [
												"Biochemical"
										]
								},
								{
										"primary_type": "Rescue",
										"secondary_type": [
												"Human",
												"Patient Cells"
										]
								}
						]
				}
    ]
}
```