### PR TITLE
Update the way comments are saved

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/serializers/curation.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/curation.py
@@ -18,7 +18,8 @@ from .locus_genotype_disease import (LocusGenotypeDiseaseSerializer,
                                      LGDCrossCuttingModifierSerializer,
                                      LGDVariantGenCCConsequenceSerializer,
                                      LGDVariantTypeSerializer, LGDVariantTypeDescriptionSerializer,
-                                     LGDMechanismSynopsisSerializer, LGDMechanismEvidenceSerializer)
+                                     LGDMechanismSynopsisSerializer, LGDMechanismEvidenceSerializer,
+                                     LGDCommentSerializer)
 from .stable_id import G2PStableIDSerializer
 from .phenotype import LGDPhenotypeSerializer
 from .publication import PublicationSerializer
@@ -633,7 +634,20 @@ class CurationDataSerializer(serializers.ModelSerializer):
         for variant_type_desc in data.json_data["variant_descriptions"]:
             LGDVariantTypeDescriptionSerializer(context={'lgd': lgd_obj}).create(variant_type_desc)
 
-        # TODO: add comment
+        # Comments
+        if "public_comment" in data.json_data and data.json_data["public_comment"] != "":
+            comment_obj_public = {
+                "comment": data.json_data["public_comment"],
+                "is_public": 1
+            }
+            LGDCommentSerializer(context={'lgd': lgd_obj, 'user': user_obj}).create(comment_obj_public)
+
+        if "private_comment" in data.json_data and data.json_data["private_comment"] != "":
+            comment_obj_private = {
+                "comment": data.json_data["private_comment"],
+                "is_public": 0
+            }
+            LGDCommentSerializer(context={'lgd': lgd_obj, 'user': user_obj}).create(comment_obj_private)
 
         # Update stable_id status to live (is_live=1)
         G2PStableIDSerializer(context={'stable_id': data.stable_id.stable_id}).update_g2p_id_status(1)

--- a/gene2phenotype_project/gene2phenotype_app/serializers/curation.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/curation.py
@@ -109,7 +109,7 @@ class CurationDataSerializer(serializers.ModelSerializer):
         if "disease" not in json_data or json_data["disease"]["disease_name"] == "":
             missing_data.append("disease")
 
-        if "confidence" not in json_data or json_data["confidence"]["level"] == "":
+        if "confidence" not in json_data or json_data["confidence"] == "":
             missing_data.append("confidence")
 
         if "publications" not in json_data or len(json_data["publications"]) == 0:
@@ -247,7 +247,7 @@ class CurationDataSerializer(serializers.ModelSerializer):
             - "genotype": Retrieved from the "allelic_requirement" key.
             - "disease": Retrieved from the nested "disease_name" key inside the "disease" dictionary.
             - "panel": Retrieved from the "panels" key.
-            - "confidence": Retrieved from the key "level" inside the "confidence" dictionary.
+            - "confidence"
 
             Args:
                 json_data (dict): A dictionary containing the JSON data to extract information from.
@@ -263,7 +263,7 @@ class CurationDataSerializer(serializers.ModelSerializer):
             "genotype": json_data.get("allelic_requirement"),
             "disease": json_data.get("disease", {}).get("disease_name"),
             "panel": json_data.get("panels"),
-            "confidence": json_data.get("confidence", {}).get("level")
+            "confidence": json_data.get("confidence", None)
         }
 
     @transaction.atomic

--- a/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
@@ -275,11 +275,19 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
 
         data = []
         for comment in lgd_comments:
-            text = { 'text':comment.comment,
-                     'date':comment.date }
+            # Format the date
+            date = None
+            if comment.date is not None:
+                date = comment.date.strftime("%Y-%m-%d")
+
+            text = { 'text': comment.comment,
+                     'date': date,
+                     'is_public': comment.is_public }
+
             # authenticated users can have access to the user name
             if authenticated_user == 1:
                 text['user'] = f"{comment.user.first_name} {comment.user.last_name}"
+
             data.append(text)
 
         return data

--- a/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
@@ -498,7 +498,6 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
         # validated_data example:
         # { "confidence": "definitive" }
         validated_confidence = validated_data.get("confidence", None)
-        is_reviewed = validated_data.get("is_reviewed", None)
 
         if(validated_confidence is not None and isinstance(validated_confidence, dict) 
            and "value" in validated_confidence):
@@ -523,10 +522,6 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
 
         # Update confidence
         instance.confidence = confidence_obj
-
-        # is_reviewed only accepts 1 or 0
-        if(is_reviewed is not None and (is_reviewed == 1 or is_reviewed == 0)):
-            instance.is_reviewed = is_reviewed
 
         # Update the 'date_review'
         instance.date_review = datetime.now()

--- a/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
@@ -413,11 +413,11 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
             # Get confidence
             try:
                 confidence_obj = Attrib.objects.get(
-                    value = confidence["level"],
+                    value = confidence,
                     type__code = "confidence_category"
                 )
             except Attrib.DoesNotExist:
-                raise serializers.ValidationError({"message": f"Invalid confidence value {confidence['level']}"})
+                raise serializers.ValidationError({"message": f"Invalid confidence value {confidence}"})
 
             # Insert new G2P record (LGD)
             lgd_obj = LocusGenotypeDisease.objects.create(
@@ -486,12 +486,9 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
     def update(self, instance, validated_data):
         """
             Method to update the record confidence.
-
-            Mandatory fields to update confidence:
-                            - confidence value
         """
         # validated_data example:
-        # {'confidence': {'value': 'definitive'}}
+        # { "confidence": "definitive" }
         validated_confidence = validated_data.get("confidence", None)
         is_reviewed = validated_data.get("is_reviewed", None)
 

--- a/gene2phenotype_project/gene2phenotype_app/serializers/panel.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/panel.py
@@ -160,6 +160,10 @@ class PanelDetailSerializer(serializers.ModelSerializer):
                 if lgd_obj['lgd__lgdvarianttype__variant_type_ot__term'] is not None:
                     variant_types.append(lgd_obj['lgd__lgdvarianttype__variant_type_ot__term'])
 
+                date_review = None
+                if lgd_obj['lgd__date_review'] is not None:
+                    date_review = lgd_obj['lgd__date_review'].strftime("%Y-%m-%d")
+
                 aggregated_data[lgd_obj['lgd__stable_id__stable_id']] = {  'locus':lgd_obj['lgd__locus__name'],
                                                                 'disease':lgd_obj['lgd__disease__name'],
                                                                 'genotype':lgd_obj['lgd__genotype__value'],
@@ -167,7 +171,7 @@ class PanelDetailSerializer(serializers.ModelSerializer):
                                                                 'variant_consequence':variant_consequences,
                                                                 'variant_type':variant_types,
                                                                 'molecular_mechanism':lgd_obj['lgd__mechanism__value'],
-                                                                'date_review':lgd_obj['lgd__date_review'],
+                                                                'last_updated':date_review,
                                                                 'stable_id':lgd_obj['lgd__stable_id__stable_id'] }
                 number_keys += 1
 

--- a/gene2phenotype_project/gene2phenotype_app/tests/views/test_locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/views/test_locus_genotype_disease.py
@@ -28,7 +28,6 @@ class LocusGenotypeDiseaseDetailEndpoint(TestCase):
         self.assertEqual(response.data["stable_id"], "G2P00001")
         self.assertEqual(response.data["genotype"], "biallelic_autosomal")
         self.assertEqual(response.data["confidence"], "definitive")
-        self.assertEqual(response.data["confidence_support"], None)
         self.assertEqual(response.data["variant_consequence"], [])
         self.assertEqual(list(response.data["variant_type"]), []),
         self.assertEqual(list(response.data["variant_description"]), []),

--- a/gene2phenotype_project/gene2phenotype_app/utils/curation_schema.json
+++ b/gene2phenotype_project/gene2phenotype_app/utils/curation_schema.json
@@ -238,14 +238,19 @@
         "confidence": {
             "type": "object",
             "properties": {
-                "justification": {
-                    "type": "string"
-                },
                 "level": {
                     "type": "string"
                 }
             },
             "required": ["level"]
+        },
+        "public_comment": {
+            "description": "General comment linked to the record available to the public",
+            "type": "string"
+        },
+        "private_comment": {
+            "description": "General comment linked to the record only available to authenticated users",
+            "type": "string"
         }
     },
     "required": ["locus"]

--- a/gene2phenotype_project/gene2phenotype_app/utils/curation_schema.json
+++ b/gene2phenotype_project/gene2phenotype_app/utils/curation_schema.json
@@ -236,13 +236,8 @@
             }
         }, 
         "confidence": {
-            "type": "object",
-            "properties": {
-                "level": {
-                    "type": "string"
-                }
-            },
-            "required": ["level"]
+            "description": "Confidence level",
+            "type": "string"
         },
         "public_comment": {
             "description": "General comment linked to the record available to the public",


### PR DESCRIPTION
Affected endpoints:
- curation: the JSON data now has the following format
```
"confidence": "strong"
"public_comment": "..."
"private_comment": "..."
```

- `lgd/str:stable_id/update_confidence/` does not accept `justification`
- `panel/name/summary/` rename 'date_review' to 'last_updated' and format date