### PR TITLE
Update datetime to be aware of the timezone

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/serializers/curation.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/curation.py
@@ -1,12 +1,8 @@
 from rest_framework import serializers
 from deepdiff import DeepDiff
-from django.utils import timezone
 from django.db import transaction
 from collections import OrderedDict
-from datetime import datetime
 import copy
-import json
-import pytz
 
 from ..models import (CurationData, Disease, User, LocusGenotypeDisease,
                       Locus, DiseaseOntologyTerm, CVMolecularMechanism,
@@ -22,6 +18,8 @@ from .locus_genotype_disease import (LocusGenotypeDiseaseSerializer,
 from .stable_id import G2PStableIDSerializer
 from .phenotype import LGDPhenotypeSerializer
 from .publication import PublicationSerializer
+
+from ..utils import get_date_now
 
 class CurationDataSerializer(serializers.ModelSerializer):
     """
@@ -279,7 +277,7 @@ class CurationDataSerializer(serializers.ModelSerializer):
 
         json_data = validated_data.get("json_data")
 
-        date_created = datetime.now()
+        date_created = get_date_now()
         date_reviewed = date_created
         session_name = json_data.get('session_name')
         stable_id = G2PStableIDSerializer.create_stable_id()
@@ -325,7 +323,7 @@ class CurationDataSerializer(serializers.ModelSerializer):
         """
 
         instance.json_data = validated_data.get('json_data')
-        instance.date_last_update = timezone.now().astimezone(pytz.timezone("Europe/London"))
+        instance.date_last_update = get_date_now()
         instance.save()
 
         return instance

--- a/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
@@ -1,6 +1,5 @@
 from rest_framework import serializers
 from django.db import connection
-from datetime import datetime
 import itertools
 
 from ..models import (Panel, Attrib,
@@ -18,6 +17,7 @@ from .locus import LocusSerializer
 from .disease import DiseaseSerializer
 from .panel import LGDPanelSerializer
 
+from ..utils import get_date_now
 
 class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
     """
@@ -438,7 +438,7 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
                 confidence_support = confidence_support,
                 is_reviewed = 1,
                 is_deleted = 0,
-                date_review = datetime.now()
+                date_review = get_date_now()
             )
 
             # Insert panels
@@ -540,7 +540,7 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
             instance.is_reviewed = is_reviewed
 
         # Update the 'date_review'
-        instance.date_review = datetime.now()
+        instance.date_review = get_date_now()
 
         # Save all updates
         instance.save()
@@ -608,7 +608,7 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
         if cv_support_obj:
             lgd_instance.mechanism_support = cv_support_obj
 
-        lgd_instance.date_review = datetime.now()
+        lgd_instance.date_review = get_date_now()
         lgd_instance.save()
 
         # The mechanism synopsis is optional
@@ -735,7 +735,7 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
                             mechanism_evidence_obj.save()
 
                     # Update LGD date_review
-                    lgd_obj.date_review = datetime.now()
+                    lgd_obj.date_review = get_date_now()
                     lgd_obj.save()
 
     class Meta:
@@ -770,7 +770,7 @@ class LGDCommentSerializer(serializers.ModelSerializer):
                     is_public = is_public,
                     is_deleted = 0,
                     user = user,
-                    date = datetime.now()
+                    date = get_date_now()
                 )
 
         return lgd_comment_obj
@@ -1165,7 +1165,7 @@ class LGDVariantTypeSerializer(serializers.ModelSerializer):
                         is_public = 1, # TODO: update
                         is_deleted = 0,
                         user = user_obj,
-                        date = datetime.now()
+                        date = get_date_now()
                     ) 
                 else:
                     if(lgd_comment_obj.is_deleted == 1):
@@ -1256,7 +1256,7 @@ class LGDVariantTypeSerializer(serializers.ModelSerializer):
                                 is_public = 1, # TODO: update
                                 is_deleted = 0,
                                 user = user_obj,
-                                date = datetime.now()
+                                date = get_date_now()
                             ) 
                         else:
                             if(lgd_comment_obj.is_deleted == 1):

--- a/gene2phenotype_project/gene2phenotype_app/serializers/panel.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/panel.py
@@ -1,9 +1,9 @@
 from rest_framework import serializers
 from django.db.models import Q
-from datetime import datetime
 
 from ..models import Panel, User, UserPanel, LGDPanel, Attrib
 
+from ..utils import get_date_now
 
 class PanelDetailSerializer(serializers.ModelSerializer):
     """
@@ -240,7 +240,7 @@ class LGDPanelSerializer(serializers.ModelSerializer):
                 lgd_panel_obj.save()
         
         # Update the 'date_review' of the LocusGenotypeDisease obj
-        lgd.date_review = datetime.now()
+        lgd.date_review = get_date_now()
         lgd.save()
 
         return lgd_panel_obj

--- a/gene2phenotype_project/gene2phenotype_app/serializers/publication.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/publication.py
@@ -1,10 +1,10 @@
 from rest_framework import serializers
-from datetime import datetime
 
 from ..models import (Publication, PublicationComment,
                       PublicationFamilies, Attrib, LGDPublication)
 from ..utils import (get_publication, get_authors)
 
+from ..utils import get_date_now
 
 class PublicationCommentSerializer(serializers.ModelSerializer):
     """
@@ -41,7 +41,7 @@ class PublicationCommentSerializer(serializers.ModelSerializer):
             publication_comment_obj = PublicationComment.objects.create(comment = comment_text,
                                                                         is_public = is_public,
                                                                         is_deleted = 0,
-                                                                        date = datetime.now(),
+                                                                        date = get_date_now(),
                                                                         publication = publication,
                                                                         user = user_obj)
 
@@ -378,7 +378,7 @@ class LGDPublicationSerializer(serializers.ModelSerializer):
             # There is a new publication linked to the LGD record, 
             # the record has to reflect the date of this change
             # update the date_review of the LGD record
-            lgd.date_review = datetime.now()
+            lgd.date_review = get_date_now()
             lgd.save()
 
         # If LGD-publication already exists then returns the existing object
@@ -389,7 +389,7 @@ class LGDPublicationSerializer(serializers.ModelSerializer):
             lgd_publication_obj.save()
             # The lgd-publication is not deleted anymore which is equivallent to
             # creating a new link, this means we have to update the record 'date_review'
-            lgd.date_review = datetime.now()
+            lgd.date_review = get_date_now()
             lgd.save()
 
         return lgd_publication_obj

--- a/gene2phenotype_project/gene2phenotype_app/utils/__init__.py
+++ b/gene2phenotype_project/gene2phenotype_app/utils/__init__.py
@@ -2,3 +2,4 @@ from .disease_utils import clean_string, get_ontology, clean_omim_disease, get_o
 from .publication_utils import get_publication, get_authors
 from .locus_utils import validate_gene
 from .phenotype_utils import validate_phenotype
+from .date_utils import get_date_now

--- a/gene2phenotype_project/gene2phenotype_app/utils/date_utils.py
+++ b/gene2phenotype_project/gene2phenotype_app/utils/date_utils.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+from datetime import datetime
+import pytz
+
+def get_date_now():
+    timezone = pytz.timezone("Europe/London")
+    date_now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    date_obj = datetime.strptime(date_now, '%Y-%m-%d %H:%M:%S')
+    aware_datetime = timezone.localize(date_obj)
+
+    return aware_datetime


### PR DESCRIPTION
This update fixes the following warning:
`RuntimeWarning: DateTimeField CurationData.date_created received a naive datetime (2025-01-10 10:15:04.039326) while time zone support is active.`

Ticket: [G2P-375](https://www.ebi.ac.uk/panda/jira/browse/G2P-375)