### PR TITLE
User log out fix

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/views/user.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/user.py
@@ -422,7 +422,7 @@ class CustomTokenRefreshView(TokenRefreshView):
         if response.status_code == 200:
             refresh_token_lifetime = request.COOKIES.get('refresh_token_lifetime') # we are getting the refresh timeline from the cookie 
             access_token_lifetime = getattr(settings, "SIMPLE_JWT", {}).get("ACCESS_TOKEN_LIFETIME", timedelta(hours=1))
-            refresh_expires = refresh_token_lifetime  # Calculate refresh expiration time
+            refresh_expires = datetime.fromisoformat(refresh_token_lifetime)  # Calculate refresh expiration time
             access_expires = datetime.utcnow() + access_token_lifetime # calculate access expiration time
             response_data['refresh_token_time'] = refresh_expires
             refresh_expires_iso = refresh_expires.isoformat()

--- a/gene2phenotype_project/gene2phenotype_app/views/user.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/user.py
@@ -420,9 +420,9 @@ class CustomTokenRefreshView(TokenRefreshView):
         response = Response(response_data, status=status.HTTP_200_OK)
     
         if response.status_code == 200:
-            refresh_token_lifetime = getattr(settings, "SIMPLE_JWT", {}).get("REFRESH_TOKEN_LIFETIME", timedelta(days=1))
+            refresh_token_lifetime = request.COOKIES.get('refresh_token_lifetime') # we are getting the refresh timeline from the cookie 
             access_token_lifetime = getattr(settings, "SIMPLE_JWT", {}).get("ACCESS_TOKEN_LIFETIME", timedelta(hours=1))
-            refresh_expires = datetime.utcnow() + refresh_token_lifetime  # Calculate refresh expiration time
+            refresh_expires = refresh_token_lifetime  # Calculate refresh expiration time
             access_expires = datetime.utcnow() + access_token_lifetime # calculate access expiration time
             response_data['refresh_token_time'] = refresh_expires
             refresh_expires_iso = refresh_expires.isoformat()


### PR DESCRIPTION
Should log out exactly 24hrs after the first login and should not refresh the logout time after every token/refresh