### PR TITLE
Standardise error messages

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
@@ -2,16 +2,30 @@ from rest_framework import serializers
 from django.db import connection, IntegrityError
 from django.db.models import Prefetch
 import itertools
+import re
 
-from ..models import (Panel, Attrib,
-                     LGDPanel, LocusGenotypeDisease, LGDVariantGenccConsequence,
-                     LGDCrossCuttingModifier, LGDPublication,
-                     LGDPhenotype, LGDVariantType, Locus,
-                     LGDComment, LGDVariantTypeComment, User,
-                     LGDMolecularMechanismEvidence, CVMolecularMechanism,
-                     OntologyTerm, Publication, LGDPhenotypeSummary,
-                     LGDVariantTypeDescription, LGDMolecularMechanismSynopsis)
-
+from ..models import (
+    Panel,
+    Attrib,
+    LGDPanel,
+    LocusGenotypeDisease,
+    LGDVariantGenccConsequence,
+    LGDCrossCuttingModifier,
+    LGDPublication,
+    LGDPhenotype,
+    LGDVariantType,
+    Locus,
+    LGDComment,
+    LGDVariantTypeComment,
+    User,
+    LGDMolecularMechanismEvidence,
+    CVMolecularMechanism,
+    OntologyTerm,
+    Publication,
+    LGDPhenotypeSummary,
+    LGDVariantTypeDescription,
+    LGDMolecularMechanismSynopsis
+)
 
 from .publication import LGDPublicationSerializer
 from .locus import LocusSerializer
@@ -1177,6 +1191,8 @@ class LGDVariantTypeSerializer(serializers.ModelSerializer):
 
             # The LGDPhenotypeSummary is created - next step is to create the LGDVariantTypeComment
             if comment != "":
+                # Remove newlines from comment
+                comment = re.sub(r"\n", " ", comment)
                 try:
                     lgd_comment_obj = LGDVariantTypeComment.objects.get(
                         comment = comment,
@@ -1268,6 +1284,8 @@ class LGDVariantTypeSerializer(serializers.ModelSerializer):
 
                     # The LGDPhenotypeSummary is created - next step is to create the LGDVariantTypeComment
                     if comment != "":
+                        # Remove newlines from comment
+                        comment = re.sub(r"\n", " ", comment)
                         try:
                             lgd_comment_obj = LGDVariantTypeComment.objects.get(
                                 comment = comment,

--- a/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
@@ -200,6 +200,7 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
 
             # Prepare the list of comments
             comments = lgd_variant.current_comments # Get the prefetched comments
+
             for comment_obj in comments:
                 comment_text = comment_obj.comment
                 # Format date
@@ -219,9 +220,13 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
                     })
 
             if accession in data and lgd_variant.publication:
+                variant_type_comments = []
+                if accession in list_of_comments:
+                    variant_type_comments = list_of_comments[accession]
+
                 # Add pmid to list of publications
                 data[accession]["publications"].append(lgd_variant.publication.pmid)
-                data[accession]["comments"] = list_of_comments[accession]
+                data[accession]["comments"] = variant_type_comments
                 # Check the variant inheritance - we group this data for each publication
                 if(lgd_variant.inherited is True):
                     data[accession]["inherited"] = lgd_variant.inherited
@@ -234,6 +239,10 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
                 if lgd_variant.publication:
                     publication_list = [lgd_variant.publication.pmid]
 
+                variant_type_comments = []
+                if accession in list_of_comments:
+                    variant_type_comments = list_of_comments[accession]
+
                 data[accession] = {
                     "term": lgd_variant.variant_type_ot.term,
                     "accession": accession,
@@ -241,7 +250,7 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
                     "de_novo": lgd_variant.de_novo,
                     "unknown_inheritance": lgd_variant.unknown_inheritance,
                     "publications": publication_list,
-                    "comments": list_of_comments[accession]
+                    "comments": variant_type_comments
                 }
 
         return data.values()

--- a/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
@@ -194,20 +194,24 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
         data = {}
 
         list_of_comments = []
+        unique_comments = set()
         for lgd_variant in queryset:
             # Prepare the list of comments
             comments = lgd_variant.current_comments # Get the prefetched comments
             for comment_obj in comments:
-                # Format date
-                date = None
-                if comment_obj.date is not None:
-                    date = comment_obj.date.strftime("%Y-%m-%d")
-                list_of_comments.append(
-                    {
-                        "text": comment_obj.comment,
-                        "date": date
-                    }
-                )
+                comment_text = comment_obj.comment
+                if comment_text not in unique_comments:
+                    # Format date
+                    date = None
+                    if comment_obj.date is not None:
+                        date = comment_obj.date.strftime("%Y-%m-%d")
+                    list_of_comments.append(
+                        {
+                            "text": comment_text,
+                            "date": date
+                        }
+                    )
+                    unique_comments.add(comment_text)
 
             accession = lgd_variant.variant_type_ot.accession
 

--- a/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
@@ -193,9 +193,9 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
         )
         data = {}
 
+        list_of_comments = []
         for lgd_variant in queryset:
             # Prepare the list of comments
-            list_of_comments = []
             comments = lgd_variant.current_comments # Get the prefetched comments
             for comment_obj in comments:
                 # Format date
@@ -1160,7 +1160,7 @@ class LGDVariantTypeSerializer(serializers.ModelSerializer):
                 lgd_variant_type_obj.save()
 
             # The LGDPhenotypeSummary is created - next step is to create the LGDVariantTypeComment
-            if(comment != ""):
+            if comment != "":
                 try:
                     lgd_comment_obj = LGDVariantTypeComment.objects.get(
                         comment = comment,
@@ -1251,7 +1251,7 @@ class LGDVariantTypeSerializer(serializers.ModelSerializer):
                         lgd_variant_type_obj.save()
 
                     # The LGDPhenotypeSummary is created - next step is to create the LGDVariantTypeComment
-                    if(comment != ""):
+                    if comment != "":
                         try:
                             lgd_comment_obj = LGDVariantTypeComment.objects.get(
                                 comment = comment,
@@ -1283,7 +1283,7 @@ class LGDVariantTypeSerializer(serializers.ModelSerializer):
 class LGDVariantTypeListSerializer(serializers.Serializer):
     """
         Serializer to accept a list of variant types.
-        Called by: LGDAddVariantTypes()
+        Called by: LGDEditVariantTypes()
     """
     variant_types = LGDVariantTypeSerializer(many=True)
 

--- a/gene2phenotype_project/gene2phenotype_app/serializers/publication.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/publication.py
@@ -1,8 +1,18 @@
 from rest_framework import serializers
+import re
 
-from ..models import (Publication, PublicationComment,
-                      PublicationFamilies, Attrib, LGDPublication)
-from ..utils import (get_publication, get_authors)
+from ..models import (
+    Publication,
+    PublicationComment,
+    PublicationFamilies,
+    Attrib,
+    LGDPublication
+)
+
+from ..utils import (
+    get_publication,
+    get_authors
+)
 
 from ..utils import get_date_now
 
@@ -28,6 +38,9 @@ class PublicationCommentSerializer(serializers.ModelSerializer):
         comment_text = data.get("comment")
         is_public = data.get("is_public")
         user_obj = self.context['user'] # gets the user from the context
+
+        # Remove newlines from comment
+        comment_text = re.sub(r"\n", " ", comment_text)
 
         # Check if comment is already stored. We consider same comment if they have the same:
         #   publication, comment text, user and it's not deleted TODO

--- a/gene2phenotype_project/gene2phenotype_app/tests/views/test_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/views/test_disease.py
@@ -43,7 +43,7 @@ class DiseaseEndpointTests(TestCase):
         response = self.client.get(self.url_disease)
 
         self.assertEqual(response.status_code, 404)
-        self.assertEqual(response.data["message"], "No matching Disease found for: CACNA1F-related Aland Island")
+        self.assertEqual(response.data["error"], "No matching Disease found for: CACNA1F-related Aland Island")
 
 class DiseaseSummaryTests(TestCase):
     """
@@ -98,4 +98,4 @@ class DiseaseSummaryTests(TestCase):
         response = self.client.get(self.url_disease)
 
         self.assertEqual(response.status_code, 404)
-        self.assertEqual(response.data["message"], "No matching Disease found for: CACNA1F-related Aland Island")
+        self.assertEqual(response.data["error"], "No matching Disease found for: CACNA1F-related Aland Island")

--- a/gene2phenotype_project/gene2phenotype_app/tests/views/test_publication.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/views/test_publication.py
@@ -48,4 +48,4 @@ class PublicationTests(TestCase):
         response = self.client.get(self.url_publication)
 
         self.assertEqual(response.status_code, 404)
-        self.assertEqual(response.data["detail"], "Invalid PMID(s): 0")
+        self.assertEqual(response.data["error"], "Invalid PMID(s): 0")

--- a/gene2phenotype_project/gene2phenotype_app/tests/views/test_search.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/views/test_search.py
@@ -134,4 +134,4 @@ class SearchTests(TestCase):
         response = self.client.get(url_search_gene)
 
         self.assertEqual(response.status_code, 404)
-        self.assertEqual(response.data["message"], "No matching Gene found for: TUBB4A")
+        self.assertEqual(response.data["error"], "No matching Gene found for: TUBB4A")

--- a/gene2phenotype_project/gene2phenotype_app/views/attrib.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/attrib.py
@@ -111,7 +111,7 @@ class AttribList(generics.ListAPIView):
             attrib_type_obj = AttribType.objects.get(code=code)
         except AttribType.DoesNotExist:
             return Response(
-                {"message": f"Attrib type {code} not found"},
+                {"error": f"Attrib type {code} not found"},
                 status=status.HTTP_404_NOT_FOUND
             )
 

--- a/gene2phenotype_project/gene2phenotype_app/views/base.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/base.py
@@ -25,7 +25,7 @@ class BaseView(generics.ListAPIView):
 
     def handle_exception(self, exc):
         if isinstance(exc, Http404):
-            return Response({"message": str(exc)}, status=status.HTTP_404_NOT_FOUND)
+            return Response({"error": str(exc)}, status=status.HTTP_404_NOT_FOUND)
 
         return super().handle_exception(exc)
 

--- a/gene2phenotype_project/gene2phenotype_app/views/disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/disease.py
@@ -193,7 +193,10 @@ class UpdateDisease(BaseAdd):
         diseases = request.data  # list of diseases {'id': ..., 'name': ...}
 
         if not isinstance(diseases, list):
-            return Response({"error": "Request should be a list"}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"error": "Request should be a list"},
+                status=status.HTTP_400_BAD_REQUEST
+            )
 
         updated_diseases = []
         errors = []
@@ -230,7 +233,7 @@ class UpdateDisease(BaseAdd):
             response_data["updated"] = updated_diseases
 
         if errors:
-            response_data["errors"] = errors
+            response_data["error"] = errors
 
         return Response(response_data, status=status.HTTP_200_OK if updated_diseases else status.HTTP_400_BAD_REQUEST)
 
@@ -242,7 +245,10 @@ class LGDUpdateDisease(BaseAdd):
         data_to_update = request.data
 
         if not isinstance(data_to_update, list):
-            return Response({"error": "Request should be a list"}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"error": "Request should be a list"},
+                status=status.HTTP_400_BAD_REQUEST
+            )
 
         updated_records = []
         errors = []
@@ -279,6 +285,6 @@ class LGDUpdateDisease(BaseAdd):
             response_data["Updated records"] = updated_records
 
         if errors:
-            response_data["Errors"] = errors
+            response_data["error"] = errors
 
         return Response(response_data, status=status.HTTP_200_OK if updated_records else status.HTTP_400_BAD_REQUEST)

--- a/gene2phenotype_project/gene2phenotype_app/views/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/locus_genotype_disease.py
@@ -707,7 +707,7 @@ class LGDEditVariantTypes(CustomPermissionAPIView):
     # Define specific permissions
     method_permissions = {
         "post": [permissions.IsAuthenticated],
-        "update": [permissions.IsAuthenticated, IsSuperUser],
+        "update": [permissions.IsAuthenticated, IsSuperUser]
     }
 
     def get_serializer_class(self, action):
@@ -771,8 +771,8 @@ class LGDEditVariantTypes(CustomPermissionAPIView):
             variant_type_data = serializer_list.validated_data.get('variant_types')
 
             # Check if list of variants is empty
-            if(not variant_type_data):
-                response = Response(
+            if not variant_type_data :
+                return Response(
                     {"error": "Empty variant type. Please provide valid data."},
                      status=status.HTTP_400_BAD_REQUEST
                 )

--- a/gene2phenotype_project/gene2phenotype_app/views/panel.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/panel.py
@@ -163,7 +163,10 @@ class LGDEditPanel(CustomPermissionAPIView):
         panel_name_input = request.data.get("name", None)
 
         if panel_name_input is None or panel_name_input == "":
-            return Response({"message": f"Please enter a panel name"}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"error": f"Please enter a panel name"},
+                status=status.HTTP_400_BAD_REQUEST
+            )
 
         # Check if panel name is valid
         panel_obj = get_object_or_404(Panel, name=panel_name_input)
@@ -174,7 +177,10 @@ class LGDEditPanel(CustomPermissionAPIView):
         user_panel_list_lower = [panel.lower() for panel in serializer.panels_names(user_obj)]
 
         if panel_name_input.lower() not in user_panel_list_lower:
-            return Response({"message": f"No permission to update panel {panel_name_input}"}, status=status.HTTP_403_FORBIDDEN)
+            return Response(
+                {"error": f"No permission to update panel {panel_name_input}"},
+                status=status.HTTP_403_FORBIDDEN
+            )
 
         lgd = get_object_or_404(LocusGenotypeDisease, stable_id__stable_id=stable_id, is_deleted=0)
 
@@ -182,9 +188,15 @@ class LGDEditPanel(CustomPermissionAPIView):
 
         if serializer_class.is_valid():
             serializer_class.save()
-            response = Response({"message": "Panel added to the G2P entry successfully."}, status=status.HTTP_201_CREATED)
+            response = Response(
+                {"message": "Panel added to the G2P entry successfully."},
+                status=status.HTTP_201_CREATED
+            )
         else:
-            response = Response({"errors": serializer_class.errors}, status=status.HTTP_400_BAD_REQUEST)
+            response = Response(
+                {"error": serializer_class.errors},
+                status=status.HTTP_400_BAD_REQUEST
+            )
 
         return response
 
@@ -209,7 +221,7 @@ class LGDEditPanel(CustomPermissionAPIView):
             LGDPanel.objects.filter(lgd=lgd_obj, panel=panel_obj, is_deleted=0).update(is_deleted=1)
         except:
             return Response(
-                {"errors": f"Could not delete panel '{panel}' for ID '{stable_id}'"},
+                {"error": f"Could not delete panel '{panel}' for ID '{stable_id}'"},
                 status=status.HTTP_400_BAD_REQUEST)
         else:
             return Response(

--- a/gene2phenotype_project/gene2phenotype_app/views/phenotype.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/phenotype.py
@@ -149,8 +149,17 @@ class LGDEditPhenotypes(CustomPermissionAPIView):
         """
         lgd = get_object_or_404(LocusGenotypeDisease, stable_id__stable_id=stable_id, is_deleted=0)
 
+        if not request.data:
+            return Response(
+                {"error": "Empty data. Please provide valid data."},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
         # Prepare the response in case the data does not follow correct format
-        response = Response({"error": "Invalid data format."}, status=status.HTTP_400_BAD_REQUEST)
+        response = Response(
+            {"error": "Invalid data format. Please provide valid data."},
+            status=status.HTTP_400_BAD_REQUEST
+        )
 
         # Check and prepare data structure the send to the serializer
         # LGDPhenotypeListSerializer accepts the phenotypes in a specific struture

--- a/gene2phenotype_project/gene2phenotype_app/views/phenotype.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/phenotype.py
@@ -150,7 +150,7 @@ class LGDEditPhenotypes(CustomPermissionAPIView):
         lgd = get_object_or_404(LocusGenotypeDisease, stable_id__stable_id=stable_id, is_deleted=0)
 
         # Prepare the response in case the data does not follow correct format
-        response = Response({"errors": "Invalid data format."}, status=status.HTTP_400_BAD_REQUEST)
+        response = Response({"error": "Invalid data format."}, status=status.HTTP_400_BAD_REQUEST)
 
         # Check and prepare data structure the send to the serializer
         # LGDPhenotypeListSerializer accepts the phenotypes in a specific struture
@@ -163,7 +163,7 @@ class LGDEditPhenotypes(CustomPermissionAPIView):
 
                 if not phenotypes_data:
                     return Response(
-                        {"errors": "Empty phenotype. Please provide valid data."},
+                        {"error": "Empty phenotype. Please provide valid data."},
                         status=status.HTTP_400_BAD_REQUEST
                     )
 
@@ -186,13 +186,13 @@ class LGDEditPhenotypes(CustomPermissionAPIView):
                         )
                     else:
                         response = Response(
-                            {"errors": serializer_class.errors},
+                            {"error": serializer_class.errors},
                             status=status.HTTP_400_BAD_REQUEST
                         )
 
             else:
                 response = Response(
-                    {"errors": serializer_list.errors},
+                    {"error": serializer_list.errors},
                     status=status.HTTP_400_BAD_REQUEST
                 )
 
@@ -206,7 +206,7 @@ class LGDEditPhenotypes(CustomPermissionAPIView):
 
                 if not phenotype_summary_data:
                     return Response(
-                        {"errors": "Empty phenotype summary. Please provide valid data."},
+                        {"error": "Empty phenotype summary. Please provide valid data."},
                         status=status.HTTP_400_BAD_REQUEST
                     )
                 
@@ -225,13 +225,13 @@ class LGDEditPhenotypes(CustomPermissionAPIView):
                         )
                     else:
                         response = Response(
-                            {"errors": serializer_class.errors},
+                            {"error": serializer_class.errors},
                             status=status.HTTP_400_BAD_REQUEST
                         )
 
             else:
                 response = Response(
-                    {"errors": serializer_summary_list.errors},
+                    {"error": serializer_summary_list.errors},
                     status=status.HTTP_400_BAD_REQUEST
                 )
 
@@ -259,7 +259,7 @@ class LGDEditPhenotypes(CustomPermissionAPIView):
             LGDPhenotype.objects.filter(lgd=lgd_obj, phenotype=phenotype_obj, is_deleted=0).update(is_deleted=1)
         except:
             return Response(
-                {"errors": f"Could not delete phenotype '{accession}' for ID '{stable_id}'"},
+                {"error": f"Could not delete phenotype '{accession}' for ID '{stable_id}'"},
                 status=status.HTTP_400_BAD_REQUEST)
         else:
             return Response(
@@ -331,7 +331,7 @@ class LGDEditPhenotypeSummary(CustomPermissionAPIView):
 
             if not phenotype_summary_data:
                 return Response(
-                    {"errors": "Empty phenotype summary. Please provide valid data."},
+                    {"error": "Empty phenotype summary. Please provide valid data."},
                     status=status.HTTP_400_BAD_REQUEST
                 )
             
@@ -351,13 +351,13 @@ class LGDEditPhenotypeSummary(CustomPermissionAPIView):
                     )
                 else:
                     response = Response(
-                        {"errors": serializer_class.errors},
+                        {"error": serializer_class.errors},
                         status=status.HTTP_400_BAD_REQUEST
                     )
 
         else:
             response = Response(
-                {"errors": serializer_summary_list.errors},
+                {"error": serializer_summary_list.errors},
                 status=status.HTTP_400_BAD_REQUEST
             )
 
@@ -380,7 +380,7 @@ class LGDEditPhenotypeSummary(CustomPermissionAPIView):
             LGDPhenotypeSummary.objects.filter(lgd=lgd_obj, summary=summary, is_deleted=0).update(is_deleted=1)
         except:
             return Response(
-                {"errors": f"Could not delete phenotype summary for ID '{stable_id}'"},
+                {"error": f"Could not delete phenotype summary for ID '{stable_id}'"},
                 status=status.HTTP_400_BAD_REQUEST
             )
         else:

--- a/gene2phenotype_project/gene2phenotype_app/views/publication.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/publication.py
@@ -240,7 +240,7 @@ class LGDEditPublications(BaseUpdate):
                 if serializer_class.is_valid():
                     serializer_class.save()
                 else:
-                    response = Response({"errors": serializer_class.errors}, status=status.HTTP_400_BAD_REQUEST)
+                    response = Response({"error": serializer_class.errors}, status=status.HTTP_400_BAD_REQUEST)
 
             # Add extra data linked to the publication - phenotypes
             # Expected structure:
@@ -262,11 +262,14 @@ class LGDEditPublications(BaseUpdate):
                             # save() is going to call create()
                             lgd_phenotype_serializer.save()
                         else:
-                            response = Response({"errors": lgd_phenotype_serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
+                            response = Response(
+                                {"error": lgd_phenotype_serializer.errors},
+                                status=status.HTTP_400_BAD_REQUEST
+                            )
                     except:
                         accession = phenotype_data["accession"]
                         return Response(
-                            {"errors": f"Could not insert phenotype '{accession}' for ID '{stable_id}'"},
+                            {"error": f"Could not insert phenotype '{accession}' for ID '{stable_id}'"},
                             status=status.HTTP_400_BAD_REQUEST
                         )
 
@@ -286,7 +289,7 @@ class LGDEditPublications(BaseUpdate):
                             lgd_phenotype_summary_serializer.save()
                     except:
                         return Response(
-                            {"errors": f"Could not insert phenotype summary for PMID '{phenotype['pmid']}'"},
+                            {"error": f"Could not insert phenotype summary for PMID '{phenotype['pmid']}'"},
                             status=status.HTTP_400_BAD_REQUEST
                         )
 
@@ -345,10 +348,16 @@ class LGDEditPublications(BaseUpdate):
                 except Exception as e:
                     return self.handle_update_exception(e, "Error while updating molecular mechanism evidence")
 
-            response = Response({'message': 'Publication added to the G2P entry successfully.'}, status=status.HTTP_201_CREATED)
+            response = Response(
+                {"message": "Publication added to the G2P entry successfully."},
+                status=status.HTTP_201_CREATED
+            )
 
         else:
-            response = Response({"errors": serializer_list.errors}, status=status.HTTP_400_BAD_REQUEST)
+            response = Response(
+                {"error": serializer_list.errors},
+                status=status.HTTP_400_BAD_REQUEST
+            )
 
         return response
 
@@ -370,7 +379,7 @@ class LGDEditPublications(BaseUpdate):
             lgd_publication_obj = LGDPublication.objects.get(lgd=lgd_obj, publication=publication_obj, is_deleted=0)
         except LGDPublication.DoesNotExist:
             return Response(
-                {"errors": f"Could not find publication '{pmid}' for ID '{stable_id}'"},
+                {"error": f"Could not find publication '{pmid}' for ID '{stable_id}'"},
                 status=status.HTTP_404_NOT_FOUND)
 
         # Before deleting this publication check if LGD record is linked to other publications
@@ -379,7 +388,7 @@ class LGDEditPublications(BaseUpdate):
         # TODO: if we are going to delete the last publication then delete LGD record
         if(queryset_all.exists() and len(queryset_all) == 1):
             return Response(
-                {"errors": f"Could not delete PMID '{pmid}' for ID '{stable_id}'"},
+                {"error": f"Could not delete PMID '{pmid}' for ID '{stable_id}'"},
                 status=status.HTTP_400_BAD_REQUEST
             )
 
@@ -390,7 +399,7 @@ class LGDEditPublications(BaseUpdate):
             lgd_publication_obj.save()
         except:
             return Response(
-                {"errors": f"Could not delete PMID '{pmid}' for ID '{stable_id}'"},
+                {"error": f"Could not delete PMID '{pmid}' for ID '{stable_id}'"},
                 status=status.HTTP_400_BAD_REQUEST)
 
         # Delete publication from other tables
@@ -402,7 +411,7 @@ class LGDEditPublications(BaseUpdate):
                 is_deleted=0).update(is_deleted=1)
         except:
             return Response(
-                {"errors": f"Could not delete PMID '{pmid}' for ID '{stable_id}'"},
+                {"error": f"Could not delete PMID '{pmid}' for ID '{stable_id}'"},
                 status=status.HTTP_400_BAD_REQUEST
             )
 
@@ -416,7 +425,7 @@ class LGDEditPublications(BaseUpdate):
                 is_deleted=0).update(is_deleted=1)
         except:
             return Response(
-                {"errors": f"Could not delete PMID '{pmid}' for ID '{stable_id}'"},
+                {"error": f"Could not delete PMID '{pmid}' for ID '{stable_id}'"},
                 status=status.HTTP_400_BAD_REQUEST
             )
 
@@ -428,7 +437,7 @@ class LGDEditPublications(BaseUpdate):
                 is_deleted=0).update(is_deleted=1)
         except:
             return Response(
-                {"errors": f"Could not delete PMID '{pmid}' for ID '{stable_id}'"},
+                {"error": f"Could not delete PMID '{pmid}' for ID '{stable_id}'"},
                 status=status.HTTP_400_BAD_REQUEST
             )
 
@@ -440,7 +449,7 @@ class LGDEditPublications(BaseUpdate):
                 is_deleted=0).update(is_deleted=1)
         except:
             return Response(
-                {"errors": f"Could not delete PMID '{pmid}' for ID '{stable_id}'"},
+                {"error": f"Could not delete PMID '{pmid}' for ID '{stable_id}'"},
                 status=status.HTTP_400_BAD_REQUEST
             )
 
@@ -467,6 +476,7 @@ class LGDEditPublications(BaseUpdate):
             #     lgd_mechanism_obj.save()
 
         return Response(
-                {"message": f"Publication '{pmid}' successfully deleted for ID '{stable_id}'"},
-                 status=status.HTTP_200_OK)
+            {"message": f"Publication '{pmid}' successfully deleted for ID '{stable_id}'"},
+            status=status.HTTP_200_OK
+        )
 

--- a/gene2phenotype_project/gene2phenotype_app/views/publication.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/publication.py
@@ -91,10 +91,10 @@ def PublicationDetail(request, pmids):
     # if any of the PMIDs is invalid raise error and display all invalid IDs
     if invalid_pmids:
         pmid_list = ", ".join(invalid_pmids)
-        response = Response({'detail': f"Invalid PMID(s): {pmid_list}"}, status=status.HTTP_404_NOT_FOUND)
+        response = Response({"error": f"Invalid PMID(s): {pmid_list}"}, status=status.HTTP_404_NOT_FOUND)
 
     else:
-        response = Response({'results': data, 'count': len(data)})
+        response = Response({"results": data, "count": len(data)})
 
     return response
 


### PR DESCRIPTION
This PR includes:
- update endpoints to print the error message under `error`, do not use `message` or `errors`.
- other small improvements