### PR TITLE
Rename table 'external_disease' to 'disease_external'

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/models.py
+++ b/gene2phenotype_project/gene2phenotype_app/models.py
@@ -698,7 +698,7 @@ class GeneDisease(models.Model):
             models.Index(fields=['disease'])
         ]
 
-class ExternalDisease(models.Model):
+class DiseaseExternal(models.Model):
     """
         Disease IDs from external sources and respective disease name.
         This data is imported in bulk from the source (ex: Mondo) and will
@@ -710,7 +710,7 @@ class ExternalDisease(models.Model):
     source = models.ForeignKey("Source", on_delete=models.PROTECT)
 
     class Meta:
-        db_table = "external_disease"
+        db_table = "disease_external"
         unique_together = ['disease', 'source']
         indexes = [
             models.Index(fields=['identifier'])

--- a/gene2phenotype_project/gene2phenotype_app/views/disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/disease.py
@@ -23,7 +23,7 @@ from gene2phenotype_app.models import (
     LocusAttrib,
     GeneDisease,
     LocusGenotypeDisease,
-    ExternalDisease
+    DiseaseExternal
 )
 
 from ..utils import clean_omim_disease
@@ -188,7 +188,7 @@ def ExternalDisease(request, ext_ids):
                     }
                 )
             else:
-                external_disease = ExternalDisease.objects.filter(identifier=disease_id)
+                external_disease = DiseaseExternal.objects.filter(identifier=disease_id)
                 if external_disease.exists():
                     data.append(
                     {


### PR DESCRIPTION
This PR fixes https://github.com/EBI-G2P/gene2phenotype_api/pull/160
The model and the function have the same name `ExternalDisease`, this is an issue.