### PR TITLE
Update panel endpoint - fix authorisation issue

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/fixtures/curation_data.json
+++ b/gene2phenotype_project/gene2phenotype_app/fixtures/curation_data.json
@@ -16,10 +16,7 @@
         },
         "locus": "RHO",
         "mechanism_evidence": [],
-        "mechanism_synopsis": {
-          "name": "",
-          "support": ""
-        },
+        "mechanism_synopsis": [],
         "molecular_mechanism": {
           "name": "",
           "support": ""

--- a/gene2phenotype_project/gene2phenotype_app/tests/curation/test_add_curation.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/curation/test_add_curation.py
@@ -51,10 +51,10 @@ class LGDAddCurationEndpoint(TestCase):
                         "pmid": "1"
                     }
                 ],
-                "mechanism_synopsis": {
+                "mechanism_synopsis": [{
                     "name": "destabilising LOF",
                     "support": "inferred"
-                },
+                }],
                 "molecular_mechanism": {
                     "name": "loss of function",
                     "support": "evidence"
@@ -153,10 +153,7 @@ class LGDAddCurationEndpoint(TestCase):
                 },
                 "locus": "RHO",
                 "mechanism_evidence": [],
-                "mechanism_synopsis": {
-                    "name": "",
-                    "support": ""
-                },
+                "mechanism_synopsis": [],
                 "molecular_mechanism": {
                     "name": "",
                     "support": ""
@@ -204,10 +201,7 @@ class LGDAddCurationEndpoint(TestCase):
                 },
                 "locus": "RHO",
                 "mechanism_evidence": [],
-                "mechanism_synopsis": {
-                    "name": "",
-                    "support": ""
-                },
+                "mechanism_synopsis": [],
                 "molecular_mechanism": {
                     "name": "",
                     "support": ""
@@ -282,10 +276,7 @@ class LGDAddCurationEndpoint(TestCase):
                 },
                 "locus": "",
                 "mechanism_evidence": [],
-                "mechanism_synopsis": {
-                    "name": "",
-                    "support": ""
-                },
+                "mechanism_synopsis": [],
                 "molecular_mechanism": {
                     "name": "",
                     "support": ""

--- a/gene2phenotype_project/gene2phenotype_app/tests/views/test_panel.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/views/test_panel.py
@@ -5,19 +5,24 @@ import datetime
 from gene2phenotype_app.models import User
 from rest_framework_simplejwt.tokens import RefreshToken
 
+
 class PanelListEndpointTests(TestCase):
     """
-        Test the panel endpoint: PanelList
+    Test the panel endpoint: PanelList
     """
-    fixtures = ["gene2phenotype_app/fixtures/user_panels.json", "gene2phenotype_app/fixtures/attribs.json"]
+
+    fixtures = [
+        "gene2phenotype_app/fixtures/user_panels.json",
+        "gene2phenotype_app/fixtures/attribs.json",
+    ]
 
     def setUp(self):
-        self.url_panels = reverse('list_panels')
+        self.url_panels = reverse("list_panels")
 
     def test_get_panel_list(self):
         """
-            Test for non-autenticated users.
-            Non-visible panels are not included in the response.
+        Test for non-autenticated users.
+        Non-visible panels are not included in the response.
         """
         response = self.client.get(self.url_panels)
         self.assertEqual(response.status_code, 200)
@@ -25,8 +30,8 @@ class PanelListEndpointTests(TestCase):
 
     def test_login_get_panel_list(self):
         """
-            Test for autenticated users.
-            All panels are included in the response.
+        Test for autenticated users.
+        All panels are included in the response.
         """
         user = User.objects.get(email="user5@test.ac.uk")
         # Create token for the user
@@ -34,65 +39,94 @@ class PanelListEndpointTests(TestCase):
         access_token = str(refresh.access_token)
 
         # Authenticate by setting cookie on the test client
-        self.client.cookies[settings.SIMPLE_JWT['AUTH_COOKIE']] = access_token
+        self.client.cookies[settings.SIMPLE_JWT["AUTH_COOKIE"]] = access_token
 
         response = self.client.get(self.url_panels)
         self.assertEqual(response.status_code, 200)
 
         self.assertEqual(response.data.get("count"), 4)
 
+
 class PanelDetailsEndpointTests(TestCase):
     """
-        Test the panel endpoint: PanelDetail
+    Test the panel endpoint: PanelDetail
     """
-    fixtures = ["gene2phenotype_app/fixtures/user_panels.json", "gene2phenotype_app/fixtures/attribs.json",
-                "gene2phenotype_app/fixtures/g2p_stable_id.json", "gene2phenotype_app/fixtures/locus.json",
-                "gene2phenotype_app/fixtures/sequence.json", "gene2phenotype_app/fixtures/disease.json",
-                "gene2phenotype_app/fixtures/ontology_term.json", "gene2phenotype_app/fixtures/source.json",
-                "gene2phenotype_app/fixtures/locus_genotype_disease.json", "gene2phenotype_app/fixtures/lgd_panel.json",
-                "gene2phenotype_app/fixtures/cv_molecular_mechanism.json"]
 
-    def setUp(self):
-        self.url_panels = reverse('panel_details', kwargs={'name': 'DD'})
+    fixtures = [
+        "gene2phenotype_app/fixtures/user_panels.json",
+        "gene2phenotype_app/fixtures/attribs.json",
+        "gene2phenotype_app/fixtures/g2p_stable_id.json",
+        "gene2phenotype_app/fixtures/locus.json",
+        "gene2phenotype_app/fixtures/sequence.json",
+        "gene2phenotype_app/fixtures/disease.json",
+        "gene2phenotype_app/fixtures/ontology_term.json",
+        "gene2phenotype_app/fixtures/source.json",
+        "gene2phenotype_app/fixtures/locus_genotype_disease.json",
+        "gene2phenotype_app/fixtures/lgd_panel.json",
+        "gene2phenotype_app/fixtures/cv_molecular_mechanism.json",
+    ]
 
     def test_get_panel_details(self):
         """
-            Get the details for a visible panel.
+        Get the details for a visible panel.
         """
-        response = self.client.get(self.url_panels)
+        url_panel_dd = reverse("panel_details", kwargs={"name": "DD"})
+        response = self.client.get(url_panel_dd)
         self.assertEqual(response.status_code, 200)
 
         expected_data = {
-            'name': 'DD',
-            'description': 'Developmental disorders',
-            'last_updated': datetime.date(2017, 4, 24),
-            'stats': {
-                'total_records': 1,
-                'total_genes': 1,
-                'by_confidence': {
-                    'definitive': 1
-                }
-            }
+            "name": "DD",
+            "description": "Developmental disorders",
+            "last_updated": datetime.date(2017, 4, 24),
+            "stats": {
+                "total_records": 1,
+                "total_genes": 1,
+                "by_confidence": {"definitive": 1},
+            },
         }
         self.assertEqual(response.data, expected_data)
+    
+    def test_panel_no_permission(self):
+        """
+        Returns code 401 for non-authenticated users when accessing a non-visible panel.
+        """
+        url_panel_ear = reverse("panel_details", kwargs={"name": "Ear"})
+        response = self.client.get(url_panel_ear)
+        self.assertEqual(response.status_code, 401)
+
+    def test_invalid_panel(self):
+        """
+        Returns code 404 when accessing an invalid panel.
+        """
+        url_panel_ear = reverse("panel_details", kwargs={"name": "Ears"})
+        response = self.client.get(url_panel_ear)
+        self.assertEqual(response.status_code, 404)
 
 class PanelSummaryEndpointTests(TestCase):
     """
-        Test the panel endpoint: PanelRecordsSummary
+    Test the panel endpoint: PanelRecordsSummary
     """
-    fixtures = ["gene2phenotype_app/fixtures/user_panels.json", "gene2phenotype_app/fixtures/attribs.json",
-                "gene2phenotype_app/fixtures/g2p_stable_id.json", "gene2phenotype_app/fixtures/locus.json",
-                "gene2phenotype_app/fixtures/sequence.json", "gene2phenotype_app/fixtures/disease.json",
-                "gene2phenotype_app/fixtures/ontology_term.json", "gene2phenotype_app/fixtures/source.json",
-                "gene2phenotype_app/fixtures/locus_genotype_disease.json", "gene2phenotype_app/fixtures/lgd_panel.json",
-                "gene2phenotype_app/fixtures/cv_molecular_mechanism.json"]
+
+    fixtures = [
+        "gene2phenotype_app/fixtures/user_panels.json",
+        "gene2phenotype_app/fixtures/attribs.json",
+        "gene2phenotype_app/fixtures/g2p_stable_id.json",
+        "gene2phenotype_app/fixtures/locus.json",
+        "gene2phenotype_app/fixtures/sequence.json",
+        "gene2phenotype_app/fixtures/disease.json",
+        "gene2phenotype_app/fixtures/ontology_term.json",
+        "gene2phenotype_app/fixtures/source.json",
+        "gene2phenotype_app/fixtures/locus_genotype_disease.json",
+        "gene2phenotype_app/fixtures/lgd_panel.json",
+        "gene2phenotype_app/fixtures/cv_molecular_mechanism.json",
+    ]
 
     def setUp(self):
-        self.url_panels = reverse('panel_summary', kwargs={'name': 'DD'})
+        self.url_panels = reverse("panel_summary", kwargs={"name": "DD"})
 
     def test_get_panel_summary(self):
         """
-            Get the summary for a visible panel.
+        Get the summary for a visible panel.
         """
         response = self.client.get(self.url_panels)
         self.assertEqual(response.status_code, 200)

--- a/gene2phenotype_project/gene2phenotype_app/tests/views/test_panel.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/views/test_panel.py
@@ -21,7 +21,7 @@ class PanelListEndpointTests(TestCase):
 
     def test_get_panel_list(self):
         """
-        Test for non-autenticated users.
+        Test for non-authenticated users.
         Non-visible panels are not included in the response.
         """
         response = self.client.get(self.url_panels)
@@ -30,7 +30,7 @@ class PanelListEndpointTests(TestCase):
 
     def test_login_get_panel_list(self):
         """
-        Test for autenticated users.
+        Test for authenticated users.
         All panels are included in the response.
         """
         user = User.objects.get(email="user5@test.ac.uk")

--- a/gene2phenotype_project/gene2phenotype_app/views/base.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/base.py
@@ -1,6 +1,6 @@
 from rest_framework import generics, status, permissions
 from django.core.exceptions import PermissionDenied
-from django.http import Http404, HttpResponse
+from django.http import Http404
 from rest_framework.response import Response
 from django.db import transaction
 from django.urls import get_resolver

--- a/gene2phenotype_project/gene2phenotype_app/views/base.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/base.py
@@ -1,11 +1,12 @@
 from rest_framework import generics, status, permissions
 from django.core.exceptions import PermissionDenied
-from django.http import Http404
+from django.http import Http404, HttpResponse
 from rest_framework.response import Response
 from django.db import transaction
 from django.urls import get_resolver
 from rest_framework.decorators import api_view
 from rest_framework.permissions import BasePermission
+from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.views import APIView
 
 import re
@@ -22,6 +23,12 @@ class BaseView(generics.ListAPIView):
             raise Http404(f"{name_type}")
         else:
             raise Http404(f"No matching {name_type} found for: {name}")
+    
+    def handle_no_permission_authentication(self, name_type, name):
+        if name is None:
+            raise AuthenticationFailed("No permission")
+        else:
+            raise AuthenticationFailed(f"No permission to access {name_type} {name}")
 
     def handle_exception(self, exc):
         if isinstance(exc, Http404):

--- a/gene2phenotype_project/gene2phenotype_app/views/panel.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/panel.py
@@ -88,6 +88,8 @@ class PanelDetail(BaseView):
         for panel in queryset:
             if panel.is_visible == 1 or (user.is_authenticated and panel.is_visible == 0):
                 flag = 1
+            elif panel.is_visible == 0 and not user.is_authenticated:
+                return self.handle_no_permission_authentication('Panel', name)
 
         if flag == 1:
             serializer = PanelDetailSerializer()

--- a/gene2phenotype_project/gene2phenotype_app/views/panel.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/panel.py
@@ -127,6 +127,8 @@ class PanelRecordsSummary(BaseView):
         for panel in queryset:
             if panel.is_visible == 1 or (user.is_authenticated and panel.is_visible == 0):
                 flag = 1
+            elif panel.is_visible == 0 and not user.is_authenticated:
+                return self.handle_no_permission_authentication('Panel', name)
 
         if flag == 1:
             serializer = PanelDetailSerializer()


### PR DESCRIPTION
Ticket: [G2P-512](https://www.ebi.ac.uk/panda/jira/browse/G2P-512)

Update the endpoint `gene2phenotype/api/panel/<name>/` to return 401 when the panel is valid but not visible.