### PR TITLE
Fix locus_genotype_disease.date_review updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ API documentation is available at [Gene2Phenotype API Documentation](https://www
 ### Installation and requirements
 The G2P requires:
 
-    * **Python 5.10**
+    * **Python 3.10**
     * **MySQL 8**
 
 ```bash

--- a/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
@@ -384,25 +384,25 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
         # Check LGD record history
         history_records = lgd_obj.history.all().values('history_user__first_name', 'history_user__last_name')
         # Check LGD cross cutting modifier history
-        history_records_ccm = LGDCrossCuttingModifier.history.filter(id=lgd_obj.id).values(
+        history_records_ccm = LGDCrossCuttingModifier.history.filter(lgd_id=lgd_obj.id).values(
                                     'history_user__first_name', 'history_user__last_name')
         # Check LGD panel history
-        history_records_lgdpanel = LGDPanel.history.filter(id=lgd_obj.id).values(
+        history_records_lgdpanel = LGDPanel.history.filter(lgd_id=lgd_obj.id).values(
                                     'history_user__first_name', 'history_user__last_name')
         # Check LGD phenotype history
-        history_records_lgdpheno = LGDPhenotype.history.filter(id=lgd_obj.id).values(
+        history_records_lgdpheno = LGDPhenotype.history.filter(lgd_id=lgd_obj.id).values(
                                     'history_user__first_name', 'history_user__last_name')
         # Check LGD publication history
-        history_records_lgdpublication = LGDPublication.history.filter(id=lgd_obj.id).values(
+        history_records_lgdpublication = LGDPublication.history.filter(lgd_id=lgd_obj.id).values(
                                     'history_user__first_name', 'history_user__last_name')
         # Check LGD variation GenCC consequence history
-        history_records_lgdvarcons = LGDVariantGenccConsequence.history.filter(id=lgd_obj.id).values(
+        history_records_lgdvarcons = LGDVariantGenccConsequence.history.filter(lgd_id=lgd_obj.id).values(
                                     'history_user__first_name', 'history_user__last_name')
         # Check LGD variation type history
-        history_records_lgdvartype = LGDVariantType.history.filter(id=lgd_obj.id).values(
+        history_records_lgdvartype = LGDVariantType.history.filter(lgd_id=lgd_obj.id).values(
                                     'history_user__first_name', 'history_user__last_name')
         # Check LGD variation type description history
-        history_records_lgdvartype_desc = LGDVariantTypeDescription.history.filter(id=lgd_obj.id).values(
+        history_records_lgdvartype_desc = LGDVariantTypeDescription.history.filter(lgd_id=lgd_obj.id).values(
                                     'history_user__first_name', 'history_user__last_name')
 
         for record in itertools.chain(history_records, history_records_ccm, history_records_lgdpanel, 

--- a/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
@@ -61,7 +61,6 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
     last_updated = serializers.SerializerMethodField()
     date_created = serializers.SerializerMethodField()
     comments = serializers.SerializerMethodField(allow_null=True)
-    curators = serializers.SerializerMethodField(allow_null=True)
     is_reviewed = serializers.IntegerField(allow_null=True, required=False, help_text="If set to 0 the record is awaiting review")
 
     def get_locus(self, id: int) -> dict[str, Any]:
@@ -372,48 +371,6 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
             date = history_records.first().history_date.date()
 
         return date
-
-    def get_curators(self, id) -> list[str]:
-        """
-            List of curators who worked on the LGMDE record.
-            Dependency: this method depends on the history table.
-            Note: entries that were migrated from the old db have limited info details.
-        """
-        list_curators = set()
-        lgd_obj = self.instance
-        # Check LGD record history
-        history_records = lgd_obj.history.all().values('history_user__first_name', 'history_user__last_name')
-        # Check LGD cross cutting modifier history
-        history_records_ccm = LGDCrossCuttingModifier.history.filter(lgd_id=lgd_obj.id).values(
-                                    'history_user__first_name', 'history_user__last_name')
-        # Check LGD panel history
-        history_records_lgdpanel = LGDPanel.history.filter(lgd_id=lgd_obj.id).values(
-                                    'history_user__first_name', 'history_user__last_name')
-        # Check LGD phenotype history
-        history_records_lgdpheno = LGDPhenotype.history.filter(lgd_id=lgd_obj.id).values(
-                                    'history_user__first_name', 'history_user__last_name')
-        # Check LGD publication history
-        history_records_lgdpublication = LGDPublication.history.filter(lgd_id=lgd_obj.id).values(
-                                    'history_user__first_name', 'history_user__last_name')
-        # Check LGD variation GenCC consequence history
-        history_records_lgdvarcons = LGDVariantGenccConsequence.history.filter(lgd_id=lgd_obj.id).values(
-                                    'history_user__first_name', 'history_user__last_name')
-        # Check LGD variation type history
-        history_records_lgdvartype = LGDVariantType.history.filter(lgd_id=lgd_obj.id).values(
-                                    'history_user__first_name', 'history_user__last_name')
-        # Check LGD variation type description history
-        history_records_lgdvartype_desc = LGDVariantTypeDescription.history.filter(lgd_id=lgd_obj.id).values(
-                                    'history_user__first_name', 'history_user__last_name')
-
-        for record in itertools.chain(history_records, history_records_ccm, history_records_lgdpanel, 
-                                      history_records_lgdpheno, history_records_lgdpublication,
-                                      history_records_lgdvarcons, history_records_lgdvartype,
-                                      history_records_lgdvartype_desc):
-            first_name = record.get('history_user__first_name')
-            last_name = record.get('history_user__last_name')
-            list_curators.add(f"{first_name} {last_name}")
-
-        return list_curators
 
     def check_user_permission(self, id, user_panels):
         """

--- a/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
@@ -579,8 +579,6 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
         
         return False
 
-            
-
     def update(self, instance, validated_data):
         """
             Method to update the record confidence.
@@ -816,9 +814,9 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
                             mechanism_evidence_obj.is_deleted = 0
                             mechanism_evidence_obj.save()
 
-                    # Update LGD date_review
-                    lgd_obj.date_review = get_date_now()
-                    lgd_obj.save()
+        # Update LGD date_review
+        lgd_obj.date_review = get_date_now()
+        lgd_obj.save()
 
     class Meta:
         model = LocusGenotypeDisease

--- a/gene2phenotype_project/gene2phenotype_app/serializers/panel.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/panel.py
@@ -282,10 +282,6 @@ class LGDPanelSerializer(serializers.ModelSerializer):
                 # If deleted then update to not deleted
                 lgd_panel_obj.is_deleted = 0
                 lgd_panel_obj.save()
-        
-        # Update the 'date_review' of the LocusGenotypeDisease obj
-        lgd.date_review = get_date_now()
-        lgd.save()
 
         return lgd_panel_obj
 

--- a/gene2phenotype_project/gene2phenotype_app/serializers/publication.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/publication.py
@@ -393,11 +393,6 @@ class LGDPublicationSerializer(serializers.ModelSerializer):
                 publication = publication_obj,
                 is_deleted = 0
             )
-            # There is a new publication linked to the LGD record, 
-            # the record has to reflect the date of this change
-            # update the date_review of the LGD record
-            lgd.date_review = get_date_now()
-            lgd.save()
 
         # If LGD-publication already exists then returns the existing object
         # New comments and/or family info are added to the existing object
@@ -405,10 +400,6 @@ class LGDPublicationSerializer(serializers.ModelSerializer):
         if lgd_publication_obj.is_deleted != 0:
             lgd_publication_obj.is_deleted = 0
             lgd_publication_obj.save()
-            # The lgd-publication is not deleted anymore which is equivallent to
-            # creating a new link, this means we have to update the record 'date_review'
-            lgd.date_review = get_date_now()
-            lgd.save()
 
         return lgd_publication_obj
 

--- a/gene2phenotype_project/gene2phenotype_app/tests/views/test_locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/views/test_locus_genotype_disease.py
@@ -36,7 +36,6 @@ class LocusGenotypeDiseaseDetailEndpoint(TestCase):
         self.assertEqual(response.data["cross_cutting_modifier"], []),
         self.assertEqual(response.data["last_updated"], "2017-04-24")
         self.assertEqual(response.data["date_created"], None)
-        self.assertEqual(response.data["curators"], set())
 
         expected_data_comments = [
             {

--- a/gene2phenotype_project/gene2phenotype_app/views/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/locus_genotype_disease.py
@@ -324,10 +324,6 @@ class VariantTypesList(APIView):
                 "last_updated": "2025-03-06",
                 "date_created": "2024-03-06",
                 "comments": [],
-                "curators": [
-                    "Louise Thompson",
-                    "Elena Cibrian"
-                ],
                 "is_reviewed": 1
             }
         )

--- a/gene2phenotype_project/gene2phenotype_app/views/panel.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/panel.py
@@ -38,6 +38,8 @@ from .base import (
     CustomPermissionAPIView
 )
 
+from ..utils import get_date_now
+
 
 @extend_schema(exclude=True)
 class PanelCreateView(generics.CreateAPIView):
@@ -326,7 +328,7 @@ class PanelRecordsSummary(BaseAPIView):
 @extend_schema(exclude=True)
 class LGDEditPanel(CustomPermissionAPIView):
     """
-        Method to add or delete LGD-panel association.
+    Method to add or delete LGD-panel association.
     """
     http_method_names = ['post', 'patch', 'options']
     serializer_class = LGDPanelSerializer
@@ -376,6 +378,9 @@ class LGDEditPanel(CustomPermissionAPIView):
 
         if serializer_class.is_valid():
             serializer_class.save()
+            # Update the 'date_review' of the LocusGenotypeDisease obj
+            lgd.date_review = get_date_now()
+            lgd.save()
             response = Response(
                 {"message": "Panel added to the G2P entry successfully."},
                 status=status.HTTP_201_CREATED
@@ -412,6 +417,9 @@ class LGDEditPanel(CustomPermissionAPIView):
                 {"error": f"Could not delete panel '{panel}' for ID '{stable_id}'"},
                 status=status.HTTP_400_BAD_REQUEST)
         else:
+            # The panel was deleted successfully - update the date of last update in the record table
+            lgd_obj.date_review = get_date_now()
+            lgd_obj.save()
             return Response(
                 {"message": f"Panel '{panel}' successfully deleted for ID '{stable_id}'"},
                  status=status.HTTP_200_OK)

--- a/gene2phenotype_project/schema.json
+++ b/gene2phenotype_project/schema.json
@@ -178,9 +178,6 @@ paths:
                     last_updated: '2025-03-06'
                     date_created: '2024-03-06'
                     comments: []
-                    curators:
-                    - Louise Thompson
-                    - Elena Cibrian
                     is_reviewed: 1
                   summary: Example 1
                   description: Fetch detailed information for record with stable_id
@@ -859,16 +856,6 @@ components:
             seen by curators.
           readOnly: true
           nullable: true
-        curators:
-          type: array
-          items:
-            type: string
-          description: |-
-            List of curators who worked on the LGMDE record.
-            Dependency: this method depends on the history table.
-            Note: entries that were migrated from the old db have limited info details.
-          readOnly: true
-          nullable: true
         is_reviewed:
           type: integer
           nullable: true
@@ -877,7 +864,6 @@ components:
       - comments
       - confidence
       - cross_cutting_modifier
-      - curators
       - date_created
       - disease
       - genotype


### PR DESCRIPTION
**Issues fixed in this PR**
- The column `locus_genotype_disease.date_review` doesn't always reflect the latest update
    I updated the serializers and views to make sure each data update also updates the `date_review`
    Note that if we insert a list of phenotypes then we should only update the date_review once - the code was updating `date_review` each time it inserted a phenotype which caused duplicated rows in the history table


- Remove `curators` from the lgd endpoint response

