### PR TITLE
hotfix - remove authorize icon from the public api

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/templates/swagger-ui.html
+++ b/gene2phenotype_project/gene2phenotype_app/templates/swagger-ui.html
@@ -6,6 +6,11 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@3/swagger-ui.css">
+    <style>
+      .swagger-ui .auth-wrapper {
+        display: none !important;
+      }
+    </style>
 </head>
 
 <body>

--- a/gene2phenotype_project/schema.json
+++ b/gene2phenotype_project/schema.json
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Gene2Phenotype (G2P)
-  version: 3.0.0
+  version: 5.0.0
   description: This API enables access to gene disease models held in the G2P database.
     See [https://www.ebi.ac.uk/gene2phenotype/](https://www.ebi.ac.uk/gene2phenotype/)
     for more details.<br><br>Contact us by submitting an issue via [https://github.com/EBI-G2P/gene2phenotype_api/issues](https://github.com/EBI-G2P/gene2phenotype_api/issues).


### PR DESCRIPTION
### Description ###
Remove the `Authorize` icon from the public API https://wwwdev.ebi.ac.uk/gene2phenotype/api/

---

### JIRA Ticket ###
No jira ticket, this is a hotfix.

---

### Contributor Checklist ###
- [x] The code compiles and runs as expected
- [x] Relevant unit tests are added or updated
- [x] All unit tests are passing
- [x] Code follows the [G2P Coding Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51871986/G2P+Coding+Guidelines)
- [x] Documentation (code comments, confluence, etc.) has been updated as needed

---

### Reviewer Checklist ###
Please **follow the [Code Review Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51937503/Code+Review+Guidelines)** when reviewing this PR.
- [x] I have followed all review guidelines