### PR TITLE
Restrict mechanism categorisation to match the mechanism value

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
@@ -690,7 +690,7 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
                 # Validate synopsis
                 mechanism_value = lgd_instance.mechanism.value
                 if not validate_mechanism_synopsis(mechanism_value, mechanism_synopsis_value):
-                    raise serializers.ValidationError({"error": f"Invalid mechanism synopsis '{mechanism_synopsis_value}' for mechanism '{mechanism_value}"})
+                    raise serializers.ValidationError({"error": f"Invalid mechanism synopsis '{mechanism_synopsis_value}' for mechanism '{mechanism_value}'"})
 
                 # Check if synopsis already exists
                 try:
@@ -985,7 +985,7 @@ class LGDMechanismSynopsisSerializer(serializers.ModelSerializer):
         # Validate the synopsis
         if not validate_mechanism_synopsis(mechanism_value, synopsis_name):
             raise serializers.ValidationError({
-                "error": f"Invalid mechanism synopsis '{synopsis_name}' for mechanism '{mechanism_value}"
+                "error": f"Invalid mechanism synopsis '{synopsis_name}' for mechanism '{mechanism_value}'"
             })
 
         return data

--- a/gene2phenotype_project/gene2phenotype_app/utils/__init__.py
+++ b/gene2phenotype_project/gene2phenotype_app/utils/__init__.py
@@ -10,3 +10,4 @@ from .phenotype_utils import validate_phenotype
 from .user_utils import CustomMail
 from .date_utils import get_date_now
 from .curationinfo_utils import ConfidenceCustomMail
+from .lgd_utils import validate_mechanism_synopsis

--- a/gene2phenotype_project/gene2phenotype_app/utils/lgd_utils.py
+++ b/gene2phenotype_project/gene2phenotype_app/utils/lgd_utils.py
@@ -25,10 +25,10 @@ def validate_mechanism_synopsis(mechanism: str, synopsis: str) -> bool:
     elif mechanism == "loss of function" and "LOF" not in synopsis:
         valid = False
     # mechanism dominant negative implies the synopsis is also DN
-    elif mechanism == "dominant negative" and re.search(r"dominant[-\s]+negative", synopsis):
+    elif mechanism == "dominant negative" and not re.search(r"dominant[-\s]+negative", synopsis):
         valid = False
     # mechanism gain of function implies the synopsis is also GOF
-    elif mechanism == "gain of function" and "GOF" not in synopsis:
+    elif mechanism == "gain of function" and "GOF" not in synopsis and "aggregation" not in synopsis:
         valid = False
 
     return valid

--- a/gene2phenotype_project/gene2phenotype_app/utils/lgd_utils.py
+++ b/gene2phenotype_project/gene2phenotype_app/utils/lgd_utils.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+import re
+
+def validate_mechanism_synopsis(mechanism: str, synopsis: str) -> bool:
+    """
+    Validate the mechanism synopsis according to the mechanism value.
+    The synopsis (categorisation) is a more specific type of mechanism
+    which means they have to match.
+
+
+    Args:
+        mechanism (str): molecular mechanism value
+        synopsis (str): mechanism synopsis value
+
+    Returns:
+        bool: returns true if the mechanism and synopsis match
+    """
+    valid = True
+
+    # undetermined and undetermined non-loss-of-function cannot have a synopsis
+    if mechanism == "undetermined" or mechanism == "undetermined non-loss-of-function":
+        valid = False
+    # mechanism loss of function implies the synopsis is also LOF
+    elif mechanism == "loss of function" and "LOF" not in synopsis:
+        valid = False
+    # mechanism dominant negative implies the synopsis is also DN
+    elif mechanism == "dominant negative" and re.search(r"dominant[-\s]+negative", synopsis):
+        valid = False
+    # mechanism gain of function implies the synopsis is also GOF
+    elif mechanism == "gain of function" and "GOF" not in synopsis:
+        valid = False
+
+    return valid

--- a/gene2phenotype_project/gene2phenotype_app/views/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/locus_genotype_disease.py
@@ -517,7 +517,7 @@ class LGDUpdateMechanism(BaseUpdate):
 
         # Get G2P entry to be updated
         lgd_obj = self.get_queryset().first()
-        serializer = LocusGenotypeDiseaseSerializer()
+        serializer = LocusGenotypeDiseaseSerializer(context={"user": user})
 
         # Check if user has permission to edit this entry
         user_obj = get_object_or_404(User, email=user, is_active=1)
@@ -628,7 +628,9 @@ class LGDEditVariantConsequences(CustomPermissionAPIView):
         user_obj = get_object_or_404(User, email=user, is_active=1)
         serializer_user = UserSerializer(user_obj, context={"user" : user})
         user_panel_list = [panel for panel in serializer_user.panels_names(user_obj)]
-        has_common = LocusGenotypeDiseaseSerializer(lgd).check_user_permission(lgd, user_panel_list)
+        # Calls method check_user_permission() to check the permissions
+        # This method requires user info in the context
+        has_common = LocusGenotypeDiseaseSerializer(lgd, context={"user": user}).check_user_permission(lgd, user_panel_list)
         if has_common is False:
             return Response({"error": f"No permission to update record '{stable_id}'"}, status=status.HTTP_403_FORBIDDEN)
 
@@ -714,7 +716,7 @@ class LGDEditVariantConsequences(CustomPermissionAPIView):
         user_obj = get_object_or_404(User, email=user, is_active=1)
         serializer_user = UserSerializer(user_obj, context={"user" : user})
         user_panel_list = [panel for panel in serializer_user.panels_names(user_obj)]
-        has_common = LocusGenotypeDiseaseSerializer(lgd_obj).check_user_permission(lgd_obj, user_panel_list)
+        has_common = LocusGenotypeDiseaseSerializer(lgd_obj, context={"user": user}).check_user_permission(lgd_obj, user_panel_list)
         if has_common is False:
             return Response({"error": f"No permission to update record '{stable_id}'"}, status=status.HTTP_403_FORBIDDEN)
 
@@ -791,7 +793,7 @@ class LGDEditCCM(CustomPermissionAPIView):
         user_obj = get_object_or_404(User, email=user, is_active=1)
         serializer_user = UserSerializer(user_obj, context={"user" : user})
         user_panel_list = [panel for panel in serializer_user.panels_names(user_obj)]
-        has_common = LocusGenotypeDiseaseSerializer(lgd).check_user_permission(lgd, user_panel_list)
+        has_common = LocusGenotypeDiseaseSerializer(lgd, context={"user": user}).check_user_permission(lgd, user_panel_list)
         if has_common is False:
             return Response(
                 {"error": f"No permission to update record '{stable_id}'"},
@@ -861,7 +863,7 @@ class LGDEditCCM(CustomPermissionAPIView):
         user_obj = get_object_or_404(User, email=user, is_active=1)
         serializer_user = UserSerializer(user_obj, context={"user" : user})
         user_panel_list = [panel for panel in serializer_user.panels_names(user_obj)]
-        has_common = LocusGenotypeDiseaseSerializer(lgd_obj).check_user_permission(lgd_obj, user_panel_list)
+        has_common = LocusGenotypeDiseaseSerializer(lgd_obj, context={"user": user}).check_user_permission(lgd_obj, user_panel_list)
         if has_common is False:
             return Response(
                 {"error": f"No permission to update record '{stable_id}'"},
@@ -950,7 +952,7 @@ class LGDEditVariantTypes(CustomPermissionAPIView):
         user_obj = get_object_or_404(User, email=user, is_active=1)
         serializer_user = UserSerializer(user_obj, context={"user" : user})
         user_panel_list = [panel for panel in serializer_user.panels_names(user_obj)]
-        has_common = LocusGenotypeDiseaseSerializer(lgd).check_user_permission(lgd, user_panel_list)
+        has_common = LocusGenotypeDiseaseSerializer(lgd, context={"user": user}).check_user_permission(lgd, user_panel_list)
         if has_common is False:
             return Response(
                 {"error": f"No permission to update record '{stable_id}'"},
@@ -1026,7 +1028,7 @@ class LGDEditVariantTypes(CustomPermissionAPIView):
         user_obj = get_object_or_404(User, email=user, is_active=1)
         serializer_user = UserSerializer(user_obj, context={"user" : user})
         user_panel_list = [panel for panel in serializer_user.panels_names(user_obj)]
-        has_common = LocusGenotypeDiseaseSerializer(lgd_obj).check_user_permission(lgd_obj, user_panel_list)
+        has_common = LocusGenotypeDiseaseSerializer(lgd_obj, context={"user": user}).check_user_permission(lgd_obj, user_panel_list)
         if has_common is False:
             return Response(
                 {"error": f"No permission to update record '{stable_id}'"},
@@ -1130,7 +1132,7 @@ class LGDEditVariantTypeDescriptions(CustomPermissionAPIView):
         user_obj = get_object_or_404(User, email=user, is_active=1)
         serializer_user = UserSerializer(user_obj, context={"user" : user})
         user_panel_list = [panel for panel in serializer_user.panels_names(user_obj)]
-        has_common = LocusGenotypeDiseaseSerializer(lgd).check_user_permission(lgd, user_panel_list)
+        has_common = LocusGenotypeDiseaseSerializer(lgd, context={"user": user}).check_user_permission(lgd, user_panel_list)
         if has_common is False:
             return Response({"error": f"No permission to update record '{stable_id}'"}, status=status.HTTP_403_FORBIDDEN)
 
@@ -1196,7 +1198,7 @@ class LGDEditVariantTypeDescriptions(CustomPermissionAPIView):
         user_obj = get_object_or_404(User, email=user, is_active=1)
         serializer_user = UserSerializer(user_obj, context={"user" : user})
         user_panel_list = [panel for panel in serializer_user.panels_names(user_obj)]
-        has_common = LocusGenotypeDiseaseSerializer(lgd_obj).check_user_permission(lgd_obj, user_panel_list)
+        has_common = LocusGenotypeDiseaseSerializer(lgd_obj, context={"user": user}).check_user_permission(lgd_obj, user_panel_list)
         if has_common is False:
             return Response({"error": f"No permission to update record '{stable_id}'"}, status=status.HTTP_403_FORBIDDEN)
 
@@ -1270,7 +1272,7 @@ class LGDEditComment(CustomPermissionAPIView):
         success_flag = 0
 
         # Check if user can edit this LGD entry
-        lgd_serializer = LocusGenotypeDiseaseSerializer(lgd)
+        lgd_serializer = LocusGenotypeDiseaseSerializer(lgd, context={"user": user})
         lgd_panels = lgd_serializer.get_panels(lgd)
         # Example of lgd_panels:
         # [{'name': 'DD', 'description': 'Developmental disorders'}, {'name': 'Eye', 'description': 'Eye disorders'}]
@@ -1352,7 +1354,7 @@ class LGDEditComment(CustomPermissionAPIView):
         user_obj = get_object_or_404(User, email=user, is_active=1)
         serializer_user = UserSerializer(user_obj, context={"user" : user})
         user_panel_list = [panel for panel in serializer_user.panels_names(user_obj)]
-        has_common = LocusGenotypeDiseaseSerializer(lgd_obj).check_user_permission(lgd_obj, user_panel_list)
+        has_common = LocusGenotypeDiseaseSerializer(lgd_obj, context={"user": user}).check_user_permission(lgd_obj, user_panel_list)
         if has_common is False:
             return Response(
                 {"error": f"No permission to update record '{stable_id}'"},
@@ -1400,7 +1402,7 @@ class LocusGenotypeDiseaseDelete(APIView):
         user_obj = get_object_or_404(User, email=user, is_active=1)
         serializer_user = UserSerializer(user_obj, context={"user" : user})
         user_panel_list = [panel for panel in serializer_user.panels_names(user_obj)]
-        has_common = LocusGenotypeDiseaseSerializer(lgd_obj).check_user_permission(lgd_obj, user_panel_list)
+        has_common = LocusGenotypeDiseaseSerializer(lgd_obj, context={"user": user}).check_user_permission(lgd_obj, user_panel_list)
         if has_common is False:
             return Response(
                 {"error": f"No permission to update record '{stable_id}'"},

--- a/gene2phenotype_project/gene2phenotype_app/views/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/locus_genotype_disease.py
@@ -558,9 +558,9 @@ class LGDUpdateMechanism(BaseUpdate):
         try:
             serializer.update_mechanism(lgd_obj, mechanism_data)
         except Exception as e:
-            if hasattr(e, "detail") and "message" in e.detail:
+            if hasattr(e, "detail") and "error" in e.detail:
                 return Response(
-                {"error": f"Error while updating molecular mechanism: {e.detail['message']}"},
+                {"error": f"Error while updating molecular mechanism: {e.detail['error']}"},
                 status=status.HTTP_400_BAD_REQUEST
             )
             else:

--- a/gene2phenotype_project/gene2phenotype_app/views/publication.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/publication.py
@@ -1,4 +1,4 @@
-from rest_framework import permissions, status
+from rest_framework import permissions, status, serializers
 from rest_framework.response import Response
 from rest_framework.decorators import api_view
 from django.db import transaction
@@ -332,6 +332,9 @@ class LGDEditPublications(BaseUpdate):
                 try:
                     # update_mechanism() updates the 'date_review' of the LGD record
                     lgd_serializer.update_mechanism(lgd, mechanism_data_input)
+                except serializers.ValidationError as e:
+                    error_message = e.detail["error"]
+                    return self.handle_update_exception(e, f"Error while updating molecular mechanism: {error_message}")
                 except Exception as e:
                     return self.handle_update_exception(e, "Error while updating molecular mechanism")
 
@@ -342,6 +345,9 @@ class LGDEditPublications(BaseUpdate):
                 lgd_serializer = LocusGenotypeDiseaseSerializer()
                 try:
                     lgd_serializer.update_mechanism_evidence(lgd, mechanism_evidence_data)
+                except serializers.ValidationError as e:
+                    error_message = e.detail["error"]
+                    return self.handle_update_exception(e, f"Error while updating molecular mechanism evidence: {error_message}")
                 except Exception as e:
                     return self.handle_update_exception(e, "Error while updating molecular mechanism evidence")
 


### PR DESCRIPTION
### Description ###
Create method `validate_mechanism_synopsis()` in utils to run some checks.
The checks are:
- If mechanism is ‘undetermined’ categorisation cannot be set
- If mechanism is ‘undetermined non LOF’ categorisation cannot be set
- If mechanism is ‘loss of function’ categorisation should match LOF
- If mechanism is ‘dominant negative’ categorisation should match ‘dominant negative’
- If mechanism is ‘gain of function’ categorisation should match GOF, protein

These checks run for:
- publish record
- update record: when we add a new mechanism synopsis
- add new publication: when we add a new mechanism synopsis

This PR also fixes two bugs related to `check_user_permission()`:
- when calling this method we have to send the user in the context for the serializer.
- replace variable name `id` by `lgd_obj` as it is more clear.

---

### JIRA Ticket ###
[[G2P-528]](https://embl.atlassian.net/browse/G2P-528)

---

### Contributor Checklist ###
- [x] The code compiles and runs as expected
- [x] Relevant unit tests are added or updated
- [x] All unit tests are passing
- [x] Code follows the [G2P Coding Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51871986/G2P+Coding+Guidelines)
- [x] Documentation (code comments, confluence, etc.) has been updated as needed

---

### Reviewer Checklist ###
Please **follow the [Code Review Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51937503/Code+Review+Guidelines)** when reviewing this PR.
- [ ] I have followed all review guidelines