### PR TITLE
Add endpoint to merge records

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/urls.py
+++ b/gene2phenotype_project/gene2phenotype_app/urls.py
@@ -249,6 +249,13 @@ urlpatterns = [
         name="update_ontology_terms"
     ),
 
+    ### Endpoints to merge or split LGD records ###
+    path(
+        "merge_records/",
+        views.MergeRecords,
+        name="merge_records"
+    ),
+
     ### Curation endpoints ###
     path(
         "add/curation/",

--- a/gene2phenotype_project/gene2phenotype_app/views/__init__.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/__init__.py
@@ -1,33 +1,76 @@
 from .base import BaseView, BaseAPIView, BaseAdd, BaseUpdate
 
-from .panel import (PanelCreateView, PanelList, PanelDetail, PanelRecordsSummary, 
-                    PanelDownload, LGDEditPanel)
+from .panel import (
+    PanelCreateView,
+    PanelList,
+    PanelDetail,
+    PanelRecordsSummary,
+    PanelDownload,
+    LGDEditPanel,
+)
 
 from .locus import LocusGene, LocusGeneSummary, GeneFunction
 
-from .disease import (GeneDiseaseView, DiseaseDetail, DiseaseSummary, AddDisease,
-                      UpdateDisease, LGDUpdateDisease, ExternalDisease,
-                      DiseaseUpdateReferences, UpdateDiseaseOntologyTerms)
+from .disease import (
+    GeneDiseaseView,
+    DiseaseDetail,
+    DiseaseSummary,
+    AddDisease,
+    UpdateDisease,
+    LGDUpdateDisease,
+    ExternalDisease,
+    DiseaseUpdateReferences,
+    UpdateDiseaseOntologyTerms,
+)
 
-from .curation import (AddCurationData, ListCurationEntries, CurationDataDetail,
-                       UpdateCurationData, PublishRecord, DeleteCurationData)
+from .curation import (
+    AddCurationData,
+    ListCurationEntries,
+    CurationDataDetail,
+    UpdateCurationData,
+    PublishRecord,
+    DeleteCurationData,
+)
 
 from .search import SearchView
 
 from .attrib import AttribTypeList, AttribTypeDescriptionList, AttribList
 
-from .user import (CreateUserView, AddUserToPanelView, LoginView, ManageUserView,
-                   UserPanels, LogOutView, CustomTokenRefreshView, ChangePasswordView, VerifyEmailView, ResetPasswordView)
+from .user import (
+    CreateUserView,
+    AddUserToPanelView,
+    LoginView,
+    ManageUserView,
+    UserPanels,
+    LogOutView,
+    CustomTokenRefreshView,
+    ChangePasswordView,
+    VerifyEmailView,
+    ResetPasswordView,
+)
 
 from .publication import PublicationDetail, AddPublication, LGDEditPublications
 
 from .meta import MetaView
 
-from .locus_genotype_disease import (ListMolecularMechanisms, VariantTypesList,
-                                     LocusGenotypeDiseaseDetail, LGDEditCCM,
-                                     LGDEditComment, LGDEditVariantConsequences,
-                                     LGDEditVariantTypes, LGDEditVariantTypeDescriptions,
-                                     LGDUpdateConfidence, LocusGenotypeDiseaseDelete,
-                                     LGDUpdateMechanism)
+from .locus_genotype_disease import (
+    ListMolecularMechanisms,
+    VariantTypesList,
+    LocusGenotypeDiseaseDetail,
+    LGDEditCCM,
+    LGDEditComment,
+    LGDEditVariantConsequences,
+    LGDEditVariantTypes,
+    LGDEditVariantTypeDescriptions,
+    LGDUpdateConfidence,
+    LocusGenotypeDiseaseDelete,
+    LGDUpdateMechanism,
+    MergeRecords,
+)
 
-from .phenotype import AddPhenotype, PhenotypeDetail, LGDEditPhenotypes, LGDEditPhenotypeSummary
+from .phenotype import (
+    AddPhenotype,
+    PhenotypeDetail,
+    LGDEditPhenotypes,
+    LGDEditPhenotypeSummary,
+)

--- a/gene2phenotype_project/gene2phenotype_app/views/disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/disease.py
@@ -576,7 +576,7 @@ class UpdateDiseaseOntologyTerms(BaseAdd):
             ontology_description = ontology_data.get("description")
 
             if not ontology_term:
-                errors.append({"error": f"Missing ontology term for '{ontology_accession}"})
+                errors.append({"error": f"Missing ontology term for '{ontology_accession}'"})
                 continue
 
             # Fetch ontology term or return 404 if not found

--- a/gene2phenotype_project/gene2phenotype_app/views/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/locus_genotype_disease.py
@@ -1519,6 +1519,7 @@ def MergeRecords(request):
                     print("Genotype to keep:", lgd_obj_keep.genotype)
                     lgd_phenos_keep = LGDPhenotype.objects.filter(lgd=lgd_obj_keep)
 
+                    # Loop through the records to be merged into 'lgd_obj_keep'
                     for g2p_id in g2p_ids:
                         try:
                             lgd_obj = LocusGenotypeDisease.objects.get(
@@ -1532,11 +1533,13 @@ def MergeRecords(request):
                         # Check if the genotype is the same
                         if lgd_obj_keep.genotype != lgd_obj.genotype:
                             print(f"ERROR: cannot merge records as genotype is different {final_g2p_id} and {g2p_id}")
-                        
-                        # Merge phenotypes
+
+                        # Fetch the phenotypes linked to the record
                         lgd_phenos = LGDPhenotype.objects.filter(lgd=lgd_obj, is_deleted=0)
+                        # Check which phenotypes are already linked to the record to keep
                         exclude_ids = list(lgd_phenos_keep.values_list('pk', flat=True))
                         lgd_phenos_diff = lgd_phenos.exclude(pk__in=exclude_ids)
+                        # Associate the remaining phenotypes to the record to keep
                         # To update the history tables, run the update with method save()
                         for lgd_pheno_obj in lgd_phenos_diff:
                             lgd_pheno_obj.lgd = lgd_obj_keep

--- a/gene2phenotype_project/gene2phenotype_app/views/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/locus_genotype_disease.py
@@ -2,11 +2,13 @@ from rest_framework import status, permissions
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from django.db import transaction, IntegrityError
+from django.db.models import Model, QuerySet
 from django.http import Http404
 from django.shortcuts import get_object_or_404
-from django.db import transaction, IntegrityError
 from drf_spectacular.utils import extend_schema, OpenApiExample
 import textwrap
+from typing import List, Type
 
 
 from gene2phenotype_app.serializers import (
@@ -1391,6 +1393,7 @@ class LocusGenotypeDiseaseDelete(APIView):
         This method deletes the LGD record.
         The deletion does not remove the entry from the database, instead
         it sets the flag 'is_deleted' to 1.
+        To keep the transaction in the history tables, the update is done by calling save().
         """
         user = request.user
 
@@ -1408,52 +1411,12 @@ class LocusGenotypeDiseaseDelete(APIView):
                 status=status.HTTP_403_FORBIDDEN
             )
 
-        # Delete the LGD record
-        lgd_obj.is_deleted = 1
-        lgd_obj.save()
+        delete_lgd_record(lgd_obj)
 
         # Delete the stable id used by the LGD record
         stable_id_obj.is_deleted = 1
         stable_id_obj.is_live = 0
         stable_id_obj.save()
-
-        # Delete lgd-cross cutting modifiers
-        LGDCrossCuttingModifier.objects.filter(lgd=lgd_obj, is_deleted=0).update(is_deleted=1)
- 
-        # Delete comments
-        LGDComment.objects.filter(lgd=lgd_obj, is_deleted=0).update(is_deleted=1)
-
-        # Delete lgd-panels
-        LGDPanel.objects.filter(lgd=lgd_obj, is_deleted=0).update(is_deleted=1)
-
-        # Delete phenotypes
-        LGDPhenotype.objects.filter(lgd=lgd_obj, is_deleted=0).update(is_deleted=1)
-
-        # Delete phenotype summary
-        LGDPhenotypeSummary.objects.filter(lgd=lgd_obj, is_deleted=0).update(is_deleted=1)
-
-        # Delete variant types + comments
-        lgd_var_type_set = LGDVariantType.objects.filter(lgd=lgd_obj, is_deleted=0)
-
-        for lgd_var_type_obj in lgd_var_type_set:
-            # Check if the lgd-variant type has comments
-            # If so, delete the comments too
-            LGDVariantTypeComment.objects.filter(lgd_variant_type=lgd_var_type_obj, is_deleted=0).update(is_deleted=1)
-            lgd_var_type_obj.is_deleted = 1
-            lgd_var_type_obj.save()
-
-        # Delete variant type description
-        LGDVariantTypeDescription.objects.filter(lgd=lgd_obj, is_deleted=0).update(is_deleted=1)
-
-        # Delete variant consequences
-        LGDVariantGenccConsequence.objects.filter(lgd=lgd_obj, is_deleted=0).update(is_deleted=1)
-
-        # Delete mechanism synopsis + evidence
-        LGDMolecularMechanismSynopsis.objects.filter(lgd=lgd_obj, is_deleted=0).update(is_deleted=1)
-        LGDMolecularMechanismEvidence.objects.filter(lgd=lgd_obj, is_deleted=0).update(is_deleted=1)
-
-        # Delete publications
-        LGDPublication.objects.filter(lgd=lgd_obj, is_deleted=0).update(is_deleted=1)
 
         return Response(
             {"message": f"ID '{stable_id}' successfully deleted"},
@@ -1467,14 +1430,18 @@ class LocusGenotypeDiseaseDelete(APIView):
 @permission_classes([IsSuperUser])
 def MergeRecords(request):
     """
-
+    Merges one or more LGD records into a target record.
 
     Args:
-        request (_type_): _description_
+        request (Request): HTTP request containing a list of records to merge
+
+    Example:
+    [
+        {"g2p_ids": ["G2P00004"], "final_g2p_id": "G2P00001"},
+        {"g2p_ids": ["G2P00005", "G2P00008"], "final_g2p_id": "G2P00006"}
+    ]
     """
     records_list = request.data
-
-    print("->", records_list)
 
     if not records_list or not isinstance(records_list, list):
         return Response(
@@ -1482,26 +1449,31 @@ def MergeRecords(request):
                 status=status.HTTP_400_BAD_REQUEST
             )
 
-    # Example:
-    # records_list = [ {"g2p_ids": ["G2P00004"], "final_g2p_id": "G2P00001"}, {"g2p_ids": ["G2P00005", "G2P00008"], "final_g2p_id": "G2P00006"} ]
+    merged_records = []
+    errors = []
+
     for record in records_list:
-        print("---")
         # record = {"g2p_ids": ["G2P00004"], "final_g2p_id": "G2P00001"}
         try:
             g2p_ids = record["g2p_ids"]
         except KeyError:
-            print(f"ERROR: g2p_ids missing from input data {record}")
+            errors.append({"error": f"g2p_ids missing from input data '{record}'"})
         else:
             # Check if the list of IDs to merge is empty
             if len(g2p_ids) == 0:
-                print(f"ERROR: empty g2p_ids {record}")
+                errors.append({"error": f"empty g2p_ids '{record}'"})
             else:
                 # Get which of the IDs is going to be kept
                 try:
                     final_g2p_id = record["final_g2p_id"]
                 except KeyError:
-                    print(f"ERROR: final_g2p_id missing from input data {record}")
+                    errors.append({"error": f"final_g2p_id missing from input data '{record}'"})
                 else:
+                    # Check the g2p id to keep is not in the list of g2p ids
+                    # This avoids merging a record into itself
+                    if final_g2p_id in g2p_ids:
+                        g2p_ids.remove(final_g2p_id)
+
                     # Data to merge:
                     # variant types, variant description, variant consequences, phenotypes,
                     # phenotype summary, publications, comments, panels, cross cutting modifiers,
@@ -1514,37 +1486,163 @@ def MergeRecords(request):
                             is_deleted = 0
                         )
                     except LocusGenotypeDisease.DoesNotExist:
-                        print(f"ERROR: invalid G2P record {final_g2p_id}")
-
-                    print("Genotype to keep:", lgd_obj_keep.genotype)
-                    lgd_phenos_keep = LGDPhenotype.objects.filter(lgd=lgd_obj_keep)
+                        errors.append({"error": f"invalid G2P record {final_g2p_id}"})
 
                     # Loop through the records to be merged into 'lgd_obj_keep'
-                    for g2p_id in g2p_ids:
-                        try:
-                            lgd_obj = LocusGenotypeDisease.objects.get(
-                                stable_id__stable_id = g2p_id,
-                                is_deleted = 0
-                            )
-                        except LocusGenotypeDisease.DoesNotExist:
-                            print(f"ERROR: invalid G2P record {g2p_id}")
-                        
-                        # Run checks before the update
-                        # Check if the genotype is the same
-                        if lgd_obj_keep.genotype != lgd_obj.genotype:
-                            print(f"ERROR: cannot merge records as genotype is different {final_g2p_id} and {g2p_id}")
+                    with transaction.atomic():
+                        for g2p_id in g2p_ids:
+                            try:
+                                lgd_obj = LocusGenotypeDisease.objects.get(
+                                    stable_id__stable_id = g2p_id,
+                                    is_deleted = 0
+                                )
+                            except LocusGenotypeDisease.DoesNotExist:
+                                errors.append({"error": f"invalid G2P record {g2p_id}"})
+                            else:
+                                # Run checks before the update
+                                # Check if the gene and genotypes are the same
+                                if lgd_obj_keep.genotype != lgd_obj.genotype:
+                                    errors.append({"error": f"cannot merge records {final_g2p_id} and {g2p_id} with different genotypes"})
+                                elif lgd_obj_keep.locus != lgd_obj.locus:
+                                    errors.append({"error": f"cannot merge records {final_g2p_id} and {g2p_id} with different genes"})
+                                else:
+                                    move_related_objects(LGDPhenotype, lgd_obj, lgd_obj_keep)
+                                    move_related_objects(LGDPhenotypeSummary, lgd_obj, lgd_obj_keep)
+                                    move_related_objects(LGDVariantTypeDescription, lgd_obj, lgd_obj_keep)
+                                    move_related_objects(LGDPublication, lgd_obj, lgd_obj_keep)
+                                    move_related_objects(LGDComment, lgd_obj, lgd_obj_keep)
+                                    move_related_objects(LGDMolecularMechanismSynopsis, lgd_obj, lgd_obj_keep)
+                                    move_related_objects(LGDCrossCuttingModifier, lgd_obj, lgd_obj_keep, ["ccm"])
+                                    move_related_objects(LGDVariantType, lgd_obj, lgd_obj_keep, ["variant_type_ot", "publication"])
+                                    move_related_objects(LGDMolecularMechanismEvidence, lgd_obj, lgd_obj_keep, ["evidence", "publication"])
+                                    move_related_objects(LGDPanel, lgd_obj, lgd_obj_keep, ["panel"])
+                                    # Variant gencc consequence has support
+                                    # How do we merge when the consequence is the same but not the support
+                                    move_related_objects(LGDVariantGenccConsequence, lgd_obj, lgd_obj_keep, ["variant_consequence", "support"])
 
-                        # Fetch the phenotypes linked to the record
-                        lgd_phenos = LGDPhenotype.objects.filter(lgd=lgd_obj, is_deleted=0)
-                        # Check which phenotypes are already linked to the record to keep
-                        exclude_ids = list(lgd_phenos_keep.values_list('pk', flat=True))
-                        lgd_phenos_diff = lgd_phenos.exclude(pk__in=exclude_ids)
-                        # Associate the remaining phenotypes to the record to keep
-                        # To update the history tables, run the update with method save()
-                        for lgd_pheno_obj in lgd_phenos_diff:
-                            lgd_pheno_obj.lgd = lgd_obj_keep
-                            lgd_pheno_obj.save()
+                                    delete_lgd_record(lgd_obj)
 
-    response = Response({"results": 0, "count": 0})
+                                    # Delete the stable id used by the LGD record
+                                    try:
+                                        stable_id_obj = G2PStableID.objects.get(id=lgd_obj.stable_id.id)
+                                    except G2PStableID.DoesNotExist:
+                                        errors.append({"error": f"invalid G2P record {g2p_id}"})
+                                    else:
+                                        stable_id_obj.is_deleted = 1
+                                        stable_id_obj.is_live = 0
+                                        stable_id_obj.save()
+                                    
+                                    merged_records.append({f"{g2p_id} merged into {final_g2p_id}"})
 
-    return response
+    response_data = {}
+    if merged_records:
+        response_data["merged_records"] = merged_records
+
+    if errors:
+        response_data["error"] = errors
+
+    return Response(response_data, status=status.HTTP_200_OK if merged_records else status.HTTP_400_BAD_REQUEST)
+
+
+def delete_lgd_record(lgd_obj: Model) -> None:
+    """
+    Method to delete the record from the main table and the data linked to it.
+    The deletion is an update of the flag 'is_deleted' to value 0.
+
+    Args:
+        lgd_obj (Model): Record to be deleted
+    """
+    # Delete lgd-cross cutting modifiers
+    for ccm in LGDCrossCuttingModifier.objects.filter(lgd=lgd_obj, is_deleted=0):
+        ccm.is_deleted = 1
+        ccm.save()
+
+    # Delete comments
+    for comment in LGDComment.objects.filter(lgd=lgd_obj, is_deleted=0):
+        comment.is_deleted = 1
+        comment.save()
+
+    # Delete lgd-panels
+    for panel in LGDPanel.objects.filter(lgd=lgd_obj, is_deleted=0):
+        panel.is_deleted = 1
+        panel.save()
+
+    # Delete phenotypes
+    for phenotypes in LGDPhenotype.objects.filter(lgd=lgd_obj, is_deleted=0):
+        phenotypes.is_deleted = 1
+        phenotypes.save()
+
+    # Delete phenotype summary
+    for pheno_summary in LGDPhenotypeSummary.objects.filter(lgd=lgd_obj, is_deleted=0):
+        pheno_summary.is_deleted = 1
+        pheno_summary.save()
+
+    # Delete variant types + comments
+    lgd_var_type_set = LGDVariantType.objects.filter(lgd=lgd_obj, is_deleted=0)
+
+    for lgd_var_type_obj in lgd_var_type_set:
+        # Check if the lgd-variant type has comments
+        # If so, delete the comments too
+        for var_comment in LGDVariantTypeComment.objects.filter(lgd_variant_type=lgd_var_type_obj, is_deleted=0):
+            var_comment.is_deleted = 1
+            var_comment.save()
+        lgd_var_type_obj.is_deleted = 1
+        lgd_var_type_obj.save()
+
+    # Delete variant type description
+    for var_description in LGDVariantTypeDescription.objects.filter(lgd=lgd_obj, is_deleted=0):
+        var_description.is_deleted = 1
+        var_description.save()
+
+    # Delete variant consequences
+    for var_consequence in LGDVariantGenccConsequence.objects.filter(lgd=lgd_obj, is_deleted=0):
+        var_consequence.is_deleted = 1
+        var_consequence.save()
+
+    # Delete mechanism synopsis
+    for mechanism_synopsis in LGDMolecularMechanismSynopsis.objects.filter(lgd=lgd_obj, is_deleted=0):
+        mechanism_synopsis.is_deleted = 1
+        mechanism_synopsis.save()
+
+    # Delete mechanism evidence
+    for mechanism_evidence in LGDMolecularMechanismEvidence.objects.filter(lgd=lgd_obj, is_deleted=0):
+        mechanism_evidence.is_deleted = 1
+        mechanism_evidence.save()
+
+    # Delete publications
+    for publication in LGDPublication.objects.filter(lgd=lgd_obj, is_deleted=0):
+        publication.is_deleted = 1
+        publication.save()
+
+    # Delete the LGD record
+    lgd_obj.is_deleted = 1
+    lgd_obj.save()
+
+
+def move_related_objects(model_class: Type[Model], lgd_obj: Model, lgd_obj_keep: Model, unique_fields: List[str] = None) -> None:
+    """
+    Method to reassign related objects from a source LGD record to a target LGD record, 
+    avoiding duplicates.
+
+    Args:
+        model_class (Type[Model]): The Django model class of the related objects
+        lgd_obj (Model): The source LocusGenotypeDisease object (to merge from)
+        lgd_obj_keep (Model): The target LocusGenotypeDisease object (to merge into)
+        unique_fields (List[str]): List of fields (besides 'lgd') that define uniqueness
+    """
+    # Fetch the objects linked to the record (to merge from)
+    objs: QuerySet = model_class.objects.filter(lgd=lgd_obj, is_deleted=0)
+
+    for obj in objs:
+        if obj.lgd_id == lgd_obj_keep.id:
+            continue
+        # Build filter for existing record in target (to merge into)
+        if unique_fields:
+            filter_args = {"lgd": lgd_obj_keep}
+            for field in unique_fields:
+                filter_args[field] = getattr(obj, field)
+            if model_class.objects.filter(**filter_args).exists():
+                continue  # Skip duplicate
+
+        obj.lgd = lgd_obj_keep
+        obj.save()


### PR DESCRIPTION
### Description ###
New endpoint: `gene2phenotype/api/merge_records/`
It accepts a list of records to merge.
Example: 
```
[ 
    {"g2p_ids": ["G2P01201"], "final_g2p_id": "G2P00413"},
    {"g2p_ids": ["G2P01200"], "final_g2p_id": "G2P00001"}
]
```

This PR also improves the view `LocusGenotypeDiseaseDelete()` called by endpoint `gene2phenotype/api/lgd/<str:stable_id>/delete/`

---

### JIRA Ticket ###
[G2P-529](https://embl.atlassian.net/browse/G2P-529)

---

### Contributor Checklist ###
- [ ] The code compiles and runs as expected
- [ ] Relevant unit tests are added or updated
- [ ] All unit tests are passing
- [ ] Code follows the [G2P Coding Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51871986/G2P+Coding+Guidelines)
- [ ] Documentation (code comments, confluence, etc.) has been updated as needed

---

### Reviewer Checklist ###
Please **follow the [Code Review Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51937503/Code+Review+Guidelines)** when reviewing this PR.
- [ ] I have followed all review guidelines