### PR TITLE
Fix bug in mechanism evidence description

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/fixtures/lgd_mechanism_evidence.json
+++ b/gene2phenotype_project/gene2phenotype_app/fixtures/lgd_mechanism_evidence.json
@@ -5,7 +5,7 @@
         "fields": {
             "lgd": 1,
             "evidence": 18,
-            "description": null,
+            "description": "This is the evidence found in PMID:3897232",
             "publication": 1,
             "is_deleted": 0
         }

--- a/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
@@ -100,6 +100,13 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
         Molecular mechanism associated with the LGMDE record.
         If available, also returns the evidence.
         """
+        user = self.context.get("user")
+        try:
+            User.objects.get(email=user)
+            authenticated_user = 1
+        except User.DoesNotExist:
+            authenticated_user = 0
+
         mechanism = id.mechanism.value
         mechanism_support = id.mechanism_support.value
         mechanism_synopsis = []
@@ -119,7 +126,7 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
             evidence_type = evidence_data.evidence.subtype.replace("_", " ").title()
             evidence_value = evidence_data.evidence.value.title()
 
-            if evidence_data.description:
+            if evidence_data.description and authenticated_user == 1:
                 evidence_description = evidence_data.description
             else:
                 evidence_description = None

--- a/gene2phenotype_project/gene2phenotype_app/tests/views/test_locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/views/test_locus_genotype_disease.py
@@ -94,7 +94,14 @@ class LocusGenotypeDiseaseDetailEndpoint(TestCase):
             "mechanism": "loss of function",
             "mechanism_support": "evidence",
             "synopsis": [{"synopsis": "assembly-mediated GOF", "support": "inferred"}],
-            "evidence": {3897232: {"Function": ["Biochemical"]}},
+            "evidence": {
+                3897232: {
+                    "functional_studies": {
+                        "Function": ["Biochemical"]
+                    },
+                    "description": None
+                }
+            },
         }
         self.assertEqual(response.data["molecular_mechanism"], expected_data_mechanism)
 

--- a/gene2phenotype_project/gene2phenotype_app/tests/views/test_locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/views/test_locus_genotype_disease.py
@@ -99,7 +99,7 @@ class LocusGenotypeDiseaseDetailEndpoint(TestCase):
                     "functional_studies": {
                         "Function": ["Biochemical"]
                     },
-                    "description": None
+                    "descriptions": []
                 }
             },
         }
@@ -157,3 +157,18 @@ class LocusGenotypeDiseaseDetailEndpoint(TestCase):
             }
         ]
         self.assertEqual(response.data["publications"], expected_data_publication)
+
+        expected_data_mechanism = {
+            "mechanism": "loss of function",
+            "mechanism_support": "evidence",
+            "synopsis": [{"synopsis": "assembly-mediated GOF", "support": "inferred"}],
+            "evidence": {
+                3897232: {
+                    "functional_studies": {
+                        "Function": ["Biochemical"]
+                    },
+                    "descriptions": ["This is the evidence found in PMID:3897232"]
+                }
+            },
+        }
+        self.assertEqual(response.data["molecular_mechanism"], expected_data_mechanism)

--- a/gene2phenotype_project/gene2phenotype_app/views/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/locus_genotype_disease.py
@@ -184,38 +184,50 @@ class VariantTypesList(APIView):
                     "synopsis": [],
                     "evidence": {
                         "30911575": {
-                            "Function": [
-                                "Biochemical",
-                                "Protein Expression"
-                            ],
-                            "Functional Alteration": [
-                                "Patient Cells"
-                            ]
+                            "functional_studies": {
+                                "Function": [
+                                    "Biochemical",
+                                    "Protein Expression"
+                                ],
+                                "Functional Alteration": [
+                                    "Patient Cells"
+                                ]
+                            },
+                            "descriptions": []
                         },
                         "21907147": {
-                            "Function": [
-                                "Biochemical"
-                            ],
-                            "Functional Alteration": [
-                                "Patient Cells"
-                            ],
-                            "Rescue": [
-                                "Patient Cells"
-                            ]
+                            "functional_studies": {
+                                "Function": [
+                                    "Biochemical"
+                                ],
+                                "Functional Alteration": [
+                                    "Patient Cells"
+                                ],
+                                "Rescue": [
+                                    "Patient Cells"
+                                ]
+                            },
+                            "descriptions": []
                         },
                         "24461907": {
-                            "Function": [
-                                "Biochemical",
-                                "Protein Expression"
-                            ]
+                            "functional_studies": {
+                                "Function": [
+                                    "Biochemical",
+                                    "Protein Expression"
+                                ]
+                            },
+                            "descriptions": []
                         },
                         "23499752": {
-                            "Function": [
-                                "Protein Expression"
-                            ],
-                            "Functional Alteration": [
-                                "Patient Cells"
-                            ]
+                            "functional_studies": {
+                                "Function": [
+                                    "Protein Expression"
+                                ],
+                                "Functional Alteration": [
+                                    "Patient Cells"
+                                ]
+                            },
+                            "descriptions": []
                         }
                     }
                 },

--- a/gene2phenotype_project/schema.json
+++ b/gene2phenotype_project/schema.json
@@ -77,38 +77,50 @@
                                                 "synopsis": [],
                                                 "evidence": {
                                                     "30911575": {
-                                                        "Function": [
-                                                            "Biochemical",
-                                                            "Protein Expression"
-                                                        ],
-                                                        "Functional Alteration": [
-                                                            "Patient Cells"
-                                                        ]
+                                                        "functional_studies": {
+                                                            "Function": [
+                                                                "Biochemical",
+                                                                "Protein Expression"
+                                                            ],
+                                                            "Functional Alteration": [
+                                                                "Patient Cells"
+                                                            ]
+                                                        },
+                                                        "descriptions": []
                                                     },
                                                     "21907147": {
-                                                        "Function": [
-                                                            "Biochemical"
-                                                        ],
-                                                        "Functional Alteration": [
-                                                            "Patient Cells"
-                                                        ],
-                                                        "Rescue": [
-                                                            "Patient Cells"
-                                                        ]
+                                                        "functional_studies": {
+                                                            "Function": [
+                                                                "Biochemical"
+                                                            ],
+                                                            "Functional Alteration": [
+                                                                "Patient Cells"
+                                                            ],
+                                                            "Rescue": [
+                                                                "Patient Cells"
+                                                            ]
+                                                        },
+                                                        "descriptions": []
                                                     },
                                                     "24461907": {
-                                                        "Function": [
-                                                            "Biochemical",
-                                                            "Protein Expression"
-                                                        ]
+                                                        "functional_studies": {
+                                                            "Function": [
+                                                                "Biochemical",
+                                                                "Protein Expression"
+                                                            ]
+                                                        },
+                                                        "descriptions": []
                                                     },
                                                     "23499752": {
-                                                        "Function": [
-                                                            "Protein Expression"
-                                                        ],
-                                                        "Functional Alteration": [
-                                                            "Patient Cells"
-                                                        ]
+                                                        "functional_studies": {
+                                                            "Function": [
+                                                                "Protein Expression"
+                                                            ],
+                                                            "Functional Alteration": [
+                                                                "Patient Cells"
+                                                            ]
+                                                        },
+                                                        "descriptions": []
                                                     }
                                                 }
                                             },


### PR DESCRIPTION
### Description ###
The mechanism evidence description is not being saved when record is published. 
Also update lgd endpoint to display the description for authenticated users. New format:
```
"molecular_mechanism": {
        "mechanism": "gain of function",
        "mechanism_support": "inferred",
        "synopsis": [
            {
                "synopsis": "assembly-mediated GOF",
                "support": "inferred"
            }
        ],
        "evidence": {
            "4": {
                "functional_studies": {
                    "Function": [
                        "Protein Interaction"
                    ],
                    "Rescue": [
                        "Patient Cells"
                    ],
                    "Functional Alteration": [
                        "Non Patient Cells"
                    ]
                },
                "descriptions": [
                    "PMID: 4 functional studies",
                    "there is more evidence in the same PMID:4"
                ]
            },
            "12": {
                "functional_studies": {
                    "Functional Alteration": [
                        "Patient Cells"
                    ]
                },
                "descriptions": []
            }
        }
    }
```

This change triggers a web update.

---

### JIRA Ticket ###
[G2P-523](https://embl.atlassian.net/browse/G2P-523)

---

### Contributor Checklist ###
- [x] The code compiles and runs as expected
- [x] Relevant unit tests are added or updated
- [x] All unit tests are passing
- [x] Code follows the [G2P Coding Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51871986/G2P+Coding+Guidelines)
- [x] Documentation (code comments, confluence, etc.) has been updated as needed

---

### Reviewer Checklist ###
Please **follow the [Code Review Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51937503/Code+Review+Guidelines)** when reviewing this PR.
- [x] I have followed all review guidelines