### PR TITLE
Add SESSION_COOKIE_SECURE to the settings

### DIFF
--- a/gene2phenotype_project/gene2phenotype_project/settings.py
+++ b/gene2phenotype_project/gene2phenotype_project/settings.py
@@ -146,6 +146,7 @@ SIMPLE_JWT = {
 CORS_ALLOWED_ORIGINS = json.loads(config.get('settings', 'CORS_ALLOWED_ORIGINS'))
 CSRF_TRUSTED_ORIGINS = json.loads(config.get('settings', 'CSRF_TRUSTED_ORIGINS'))
 CORS_ALLOWED_CREDENTIALS = True
+SESSION_COOKIE_SECURE = True
 
 DEFAULT_FROM_EMAIL = config.get('email', 'from')
 MAIL_HOST = config.get('email', 'host')


### PR DESCRIPTION
### Description ###
Set `SESSION_COOKIE_SECURE` to true to make sure the session cookie is only sent over HTTPS connections.

---

### JIRA Ticket ###
No ticket

---

### Contributor Checklist ###
- [x] The code compiles and runs as expected
- [x] Relevant unit tests are added or updated
- [x] All unit tests are passing
- [x] Code follows the [G2P Coding Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51871986/G2P+Coding+Guidelines)
- [x] Documentation (code comments, confluence, etc.) has been updated as needed

---

### Reviewer Checklist ###
Please **follow the [Code Review Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51937503/Code+Review+Guidelines)** when reviewing this PR.
- [ ] I have followed all review guidelines