### PR TITLE
Make is_reviewed optional when updating confidence

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
@@ -62,7 +62,7 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
     last_updated = serializers.SerializerMethodField()
     date_created = serializers.SerializerMethodField()
     comments = serializers.SerializerMethodField(allow_null=True)
-    is_reviewed = serializers.BooleanField() # It is the same as SmallInteger 0/1
+    is_reviewed = serializers.BooleanField(required=False) # It is the same as SmallInteger 0/1
 
     def get_locus(self, id: int) -> dict[str, Any]:
         """

--- a/gene2phenotype_project/gene2phenotype_app/tests/update_data/test_update_lgd_confidence.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/update_data/test_update_lgd_confidence.py
@@ -1,0 +1,116 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.conf import settings
+from rest_framework_simplejwt.tokens import RefreshToken
+from gene2phenotype_app.models import User
+
+
+class LGDUpdateLGDConfidence(TestCase):
+    """
+    Test endpoint to update the record confidence
+    """
+
+    fixtures = [
+        "gene2phenotype_app/fixtures/attribs.json",
+        "gene2phenotype_app/fixtures/cv_molecular_mechanism.json",
+        "gene2phenotype_app/fixtures/disease.json",
+        "gene2phenotype_app/fixtures/g2p_stable_id.json",
+        "gene2phenotype_app/fixtures/lgd_mechanism_evidence.json",
+        "gene2phenotype_app/fixtures/lgd_mechanism_synopsis.json",
+        "gene2phenotype_app/fixtures/lgd_panel.json",
+        "gene2phenotype_app/fixtures/locus_genotype_disease.json",
+        "gene2phenotype_app/fixtures/locus.json",
+        "gene2phenotype_app/fixtures/publication.json",
+        "gene2phenotype_app/fixtures/sequence.json",
+        "gene2phenotype_app/fixtures/user_panels.json",
+        "gene2phenotype_app/fixtures/ontology_term.json",
+        "gene2phenotype_app/fixtures/source.json",
+    ]
+
+    def setUp(self):
+        self.url_lgd_confidence = reverse(
+            "lgd_update_confidence", kwargs={"stable_id": "G2P00001"}
+        )
+
+    def test_invalid_update(self):
+        """
+        Test updating confidence with invalid input data
+        """
+        input_data = {}
+
+        # Login
+        user = User.objects.get(email="user5@test.ac.uk")
+        refresh = RefreshToken.for_user(user)
+        access_token = str(refresh.access_token)
+
+        # Authenticate by setting cookie on the test client
+        self.client.cookies[settings.SIMPLE_JWT["AUTH_COOKIE"]] = access_token
+
+        response = self.client.put(
+            self.url_lgd_confidence, input_data, content_type="application/json"
+        )
+        self.assertEqual(response.status_code, 400)
+
+        response_data = response.json()
+        expected_error = {"confidence": ["This field is required."]}
+        self.assertEqual(response_data["error"], expected_error)
+
+    def test_no_permission(self):
+        """
+        Test updating record confidence without being authenticated
+        """
+        input_data = {"confidence": "definitive"}
+
+        response = self.client.put(
+            self.url_lgd_confidence, input_data, content_type="application/json"
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_update_same_value(self):
+        """
+        Test updating the confidence to the same value
+        """
+        input_data = {"confidence": "definitive"}
+
+        # Login
+        user = User.objects.get(email="user5@test.ac.uk")
+        refresh = RefreshToken.for_user(user)
+        access_token = str(refresh.access_token)
+
+        # Authenticate by setting cookie on the test client
+        self.client.cookies[settings.SIMPLE_JWT["AUTH_COOKIE"]] = access_token
+
+        response = self.client.put(
+            self.url_lgd_confidence, input_data, content_type="application/json"
+        )
+        self.assertEqual(response.status_code, 400)
+
+        response_data = response.json()
+        self.assertEqual(
+            response_data["error"],
+            "G2P record 'G2P00001' already has confidence value definitive",
+        )
+
+    def test_valid_update(self):
+        """
+        Test successfully updating the record confidence
+        """
+        input_data = {"confidence": "limited"}
+
+        # Login
+        user = User.objects.get(email="user5@test.ac.uk")
+        refresh = RefreshToken.for_user(user)
+        access_token = str(refresh.access_token)
+
+        # Authenticate by setting cookie on the test client
+        self.client.cookies[settings.SIMPLE_JWT["AUTH_COOKIE"]] = access_token
+
+        response = self.client.put(
+            self.url_lgd_confidence, input_data, content_type="application/json"
+        )
+        self.assertEqual(response.status_code, 200)
+
+        response_data = response.json()
+        self.assertEqual(
+            response_data["message"], "Data updated successfully for 'G2P00001'"
+        )


### PR DESCRIPTION
### Description ###
In this PR https://github.com/EBI-G2P/gene2phenotype_api/pull/212 the confidence was updated to be mandatory by mistake.
This PR adds the `required=False` back.
It also adds tests.

---

### JIRA Ticket ###
Test confidence update: [G2P-483](https://embl.atlassian.net/browse/G2P-483)

---

### Contributor Checklist ###
- [x] The code compiles and runs as expected
- [x] Relevant unit tests are added or updated
- [x] All unit tests are passing
- [x] Code follows the [G2P Coding Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51871986/G2P+Coding+Guidelines)
- [x] Documentation (code comments, confluence, etc.) has been updated as needed

---

### Reviewer Checklist ###
Please **follow the [Code Review Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51937503/Code+Review+Guidelines)** when reviewing this PR.
- [ ] I have followed all review guidelines