### PR TITLE
Create custom command to migrate publication families data to new table

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/management/commands/import_publication_families_data.py
+++ b/gene2phenotype_project/gene2phenotype_app/management/commands/import_publication_families_data.py
@@ -9,6 +9,11 @@ from gene2phenotype_app.models import (
     User,
 )
 
+"""
+Command to import publication family information from a csv file.
+File format is the following:
+    g2p id,lgd_id,pmid,publication_id,number of families,affected individuals,ancestries,consanguinity
+"""
 
 class Command(BaseCommand):
     def add_arguments(self, parser):

--- a/gene2phenotype_project/gene2phenotype_app/management/commands/import_publication_families_data.py
+++ b/gene2phenotype_project/gene2phenotype_app/management/commands/import_publication_families_data.py
@@ -1,0 +1,82 @@
+import csv
+
+from django.core.management.base import BaseCommand, CommandError
+from gene2phenotype_app.models import (
+    Attrib,
+    Publication,
+    LGDPublication,
+    LocusGenotypeDisease,
+)
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--data_file",
+            required=True,
+            type=str,
+            help="Input file with publication families data",
+        )
+
+    def handle(self, *args, **options):
+        data_file = options["data_file"]
+
+        with open(data_file, newline="") as fh_file:
+            data_reader = csv.DictReader(fh_file)
+            for row in data_reader:
+                # Get consanguinity object
+                consanguinity_value = row["consanguinity"].strip()
+                try:
+                    consanguinity_obj = Attrib.objects.get(
+                        value=consanguinity_value, type__code="consanguinity"
+                    )
+                except Attrib.DoesNotExist:
+                    raise CommandError(f"Invalid consanguinity '{consanguinity_value}'")
+
+                # Get publication object
+                pmid_value = row["pmid"].strip()
+                try:
+                    publication_obj = Publication.objects.get(pmid=pmid_value)
+                except Publication.DoesNotExist:
+                    raise CommandError(f"Invalid PMID '{pmid_value}'")
+
+                # Get record object
+                lgd_id = row["lgd_id"].strip()
+                try:
+                    lgd_obj = LocusGenotypeDisease.objects.get(id=lgd_id)
+                except LocusGenotypeDisease.DoesNotExist:
+                    raise CommandError(f"Invalid record ID '{lgd_id}'")
+
+                # Get the LGDPublication obj to be updated
+                try:
+                    lgd_publication_obj = LGDPublication.objects.get(
+                        lgd=lgd_obj, publication=publication_obj
+                    )
+                except LGDPublication.DoesNotExist:
+                    raise CommandError(
+                        f"Cannot fetch lgd-publication {lgd_id}-{publication_obj.id}"
+                    )
+
+                # Checking if lgd-publication already has families counts
+                if lgd_publication_obj.number_of_families:
+                    raise CommandError(
+                        f"Cannot update lgd-publication {lgd_id}-{publication_obj.id} as it already has families data"
+                    )
+
+                try:
+                    lgd_publication_obj.number_of_families = row[
+                        "number of families"
+                    ].strip()
+                    lgd_publication_obj.consanguinity = consanguinity_obj
+                    lgd_publication_obj.affected_individuals = row[
+                        "affected individuals"
+                    ].strip()
+                    lgd_publication_obj.ancestry = row["ancestries"].strip()
+                    lgd_publication_obj.save()
+                except Exception as e:
+                    raise CommandError(
+                        f"Cannot save data for PMID '{pmid_value}' for record '{lgd_id}'",
+                        str(e),
+                    )
+                else:
+                    self.stdout.write("Data updated successfully")


### PR DESCRIPTION
### Description ###
Create a custom management command to migrate the publication-families data to the new table.
The script checks if the new table already has families/affected individuals data, this way there is no problem if the command is run by mistake in the future.
Requirements: input file with data to be migrated - the file is being reviewed manually

How to run the command:
`python manage.py import_publication_families_data --data_file <file> --email <email>`

---

### JIRA Ticket ###
[G2P-577](https://embl.atlassian.net/browse/G2P-577)

---

### Contributor Checklist ###
- [x] The code compiles and runs as expected
- [x] Relevant unit tests are added or updated
- [x] All unit tests are passing
- [x] Code follows the [G2P Coding Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51871986/G2P+Coding+Guidelines)
- [x] Documentation (code comments, confluence, etc.) has been updated as needed

---

### Reviewer Checklist ###
Please **follow the [Code Review Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51937503/Code+Review+Guidelines)** when reviewing this PR.
- [ ] I have followed all review guidelines