### PR TITLE
Check for empty string before inserting ancestry

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/serializers/publication.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/publication.py
@@ -275,6 +275,10 @@ class LGDPublicationSerializer(serializers.ModelSerializer):
         consanguinity = validated_data.get("consanguinity", None)
         consanguinity_obj = None
 
+        # Check if ancestry is empty string
+        if ancestry == "":
+            ancestry = None
+
         # Get consanguinity from attrib
         if consanguinity:
             try:


### PR DESCRIPTION
### Description ###
If there is no publication ancestry, set the value to None to avoid inserting emtpy string in the db.

---

### JIRA Ticket ###
No ticket

---

### Contributor Checklist ###
- [ ] The code compiles and runs as expected
- [ ] Relevant unit tests are added or updated
- [ ] All unit tests are passing
- [ ] Code follows the [G2P Coding Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51871986/G2P+Coding+Guidelines)
- [ ] Documentation (code comments, confluence, etc.) has been updated as needed

---

### Reviewer Checklist ###
Please **follow the [Code Review Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51937503/Code+Review+Guidelines)** when reviewing this PR.
- [ ] I have followed all review guidelines