### PR TITLE
Improve endpoint to delete LGD comments

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/fixtures/disease_external.json
+++ b/gene2phenotype_project/gene2phenotype_app/fixtures/disease_external.json
@@ -1,0 +1,110 @@
+[
+    {
+        "model": "gene2phenotype_app.diseaseexternal",
+        "pk": 1,
+        "fields": {
+            "disease": "primary peritoneal serous/papillary carcinoma",
+            "identifier": "MONDO:0018368",
+            "source": 3
+        }
+    },
+    {
+        "model": "gene2phenotype_app.diseaseexternal",
+        "pk": 2,
+        "fields": {
+            "disease": "spatial visualization, aptitude for",
+            "identifier": "MONDO:0010734",
+            "source": 3
+        }
+    },
+    {
+        "model": "gene2phenotype_app.diseaseexternal",
+        "pk": 3,
+        "fields": {
+            "disease": "ocular surface squamous neoplasia",
+            "identifier": "MONDO:0971056",
+            "source": 3
+        }
+    },
+    {
+        "model": "gene2phenotype_app.diseaseexternal",
+        "pk": 4,
+        "fields": {
+            "disease": "Keipert syndrome",
+            "identifier": "MONDO:0009720",
+            "source": 3
+        }
+    },
+    {
+        "model": "gene2phenotype_app.diseaseexternal",
+        "pk": 5,
+        "fields": {
+            "disease": "SBDS-related severe neonatal spondylometaphyseal dysplasia",
+            "identifier": "MONDO:0850096",
+            "source": 3
+        }
+    },
+    {
+        "model": "gene2phenotype_app.diseaseexternal",
+        "pk": 6,
+        "fields": {
+            "disease": "sinonasal undifferentiated carcinoma",
+            "identifier": "MONDO:0006411",
+            "source": 3
+        }
+    },
+    {
+        "model": "gene2phenotype_app.diseaseexternal",
+        "pk": 7,
+        "fields": {
+            "disease": "circumscribed palmoplantar hypokeratosis",
+            "identifier": "MONDO:0019076",
+            "source": 3
+        }
+    },
+    {
+        "model": "gene2phenotype_app.diseaseexternal",
+        "pk": 8,
+        "fields": {
+            "disease": "otosclerosis 5",
+            "identifier": "MONDO:0012121",
+            "source": 3
+        }
+    },
+    {
+        "model": "gene2phenotype_app.diseaseexternal",
+        "pk": 9,
+        "fields": {
+            "disease": "squamous cell skin papilloma",
+            "identifier": "MONDO:0004204",
+            "source": 3
+        }
+    },
+    {
+        "model": "gene2phenotype_app.diseaseexternal",
+        "pk": 10,
+        "fields": {
+            "disease": "COACH syndrome 1",
+            "identifier": "MONDO:0800103",
+            "source": 3
+        }
+    },
+    {
+        "model": "gene2phenotype_app.diseaseexternal",
+        "pk": 249,
+        "fields": {
+            "disease": "Joubert syndrome 15",
+            "identifier": "MONDO:0013763",
+            "source": 3
+        }
+    },
+    {
+        "model": "gene2phenotype_app.diseaseexternal",
+        "pk": 5680,
+        "fields": {
+            "disease": "Senior-Loken syndrome",
+            "identifier": "MONDO:0017842",
+            "source": 3
+        }
+    }
+]

--- a/gene2phenotype_project/gene2phenotype_app/fixtures/user_panels.json
+++ b/gene2phenotype_project/gene2phenotype_app/fixtures/user_panels.json
@@ -90,6 +90,21 @@
         }
     },
     {
+        "model": "gene2phenotype_app.user",
+        "pk": 7,
+        "fields": {
+            "password": "pbkdf2_sha256$720000$w5I3Bm9k1tX10ZHYbkyXiB$MAOsldxIofWkGpKIVTvgpBp3hWGBfCCwrpuRedueshE=",
+            "is_staff": false,
+            "is_active": true,
+            "username": "test_user_mary",
+            "email": "mary@test.ac.uk",
+            "is_deleted": false,
+            "is_superuser": 0,
+            "first_name": "Mary",
+            "last_name": "Smith"
+        }
+    },
+    {
         "model": "gene2phenotype_app.panel",
         "pk": 1,
         "fields": {
@@ -122,6 +137,15 @@
         "fields": {
             "name": "Cardiac",
             "description": "Cardiac disorders",
+            "is_visible": 1
+        }
+    },
+    {
+        "model": "gene2phenotype_app.panel",
+        "pk": 5,
+        "fields": {
+            "name": "Cancer",
+            "description": "Cancer disorders",
             "is_visible": 1
         }
     },
@@ -266,6 +290,15 @@
         "fields": {
             "user": 6,
             "panel": 4,
+            "is_deleted": 0
+        }
+    },
+    {
+        "model": "gene2phenotype_app.userpanel",
+        "pk": 17,
+        "fields": {
+            "user": 7,
+            "panel": 5,
             "is_deleted": 0
         }
     }

--- a/gene2phenotype_project/gene2phenotype_app/tests/delete_data/test_delete_lgd_comment.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/delete_data/test_delete_lgd_comment.py
@@ -56,7 +56,29 @@ class LGDDeleteComment(TestCase):
 
         response_data = response.json()
         self.assertEqual(
-            response_data["error"], "Cannot delete comment for ID 'G2P00002'"
+            response_data["error"], "Cannot delete comment for record 'G2P00002'"
+        )
+
+    def test_delete_no_permission(self):
+        """
+        Test deleting the comment for non authenticated users.
+        """
+        # Login
+        user = User.objects.get(email="mary@test.ac.uk")
+        refresh = RefreshToken.for_user(user)
+        access_token = str(refresh.access_token)
+
+        # Authenticate by setting cookie on the test client
+        self.client.cookies[settings.SIMPLE_JWT["AUTH_COOKIE"]] = access_token
+
+        response = self.client.patch(
+            self.url_delete, self.comment_to_delete, content_type="application/json"
+        )
+        self.assertEqual(response.status_code, 403)
+
+        response_data = response.json()
+        self.assertEqual(
+            response_data["error"], "No permission to update record 'G2P00002'"
         )
 
     def test_delete_non_superuser(self):

--- a/gene2phenotype_project/gene2phenotype_app/tests/views/test_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/views/test_disease.py
@@ -1,22 +1,26 @@
 from django.test import TestCase
 from django.urls import reverse
 
+
 class DiseaseEndpointTests(TestCase):
     """
-        Test the disease endpoint: DiseaseDetail
+    Test the disease endpoint: DiseaseDetail
     """
+
     fixtures = [
         "gene2phenotype_app/fixtures/disease.json",
         "gene2phenotype_app/fixtures/attribs.json",
         "gene2phenotype_app/fixtures/source.json",
-        "gene2phenotype_app/fixtures/ontology_term.json"
+        "gene2phenotype_app/fixtures/ontology_term.json",
     ]
 
     def test_get_disease(self):
         """
-            Test the response of the disease detail endpoint
+        Test the response of the disease detail endpoint
         """
-        self.url_disease = reverse("disease_details", kwargs={"id": "Congenital ichthyosis type 1"})
+        self.url_disease = reverse(
+            "disease_details", kwargs={"id": "Congenital ichthyosis type 1"}
+        )
 
         response = self.client.get(self.url_disease)
 
@@ -25,30 +29,39 @@ class DiseaseEndpointTests(TestCase):
         self.assertEqual(response.data["last_updated"], None)
         self.assertEqual(response.data["synonyms"], [])
 
-        expected_data = [{
-            "accession": "MONDO:0009441",
-            "term": "MONDO:0009441",
-            "description": "Any autosomal recessive congenital ichthyosis in which the cause of the disease is a mutation in the TGM1 gene.",
-            "source": "Mondo"
-        }]
+        expected_data = [
+            {
+                "accession": "MONDO:0009441",
+                "term": "MONDO:0009441",
+                "description": "Any autosomal recessive congenital ichthyosis in which the cause of the disease is a mutation in the TGM1 gene.",
+                "source": "Mondo",
+            }
+        ]
         self.assertEqual(list(response.data["ontology_terms"]), expected_data)
 
     def test_not_found(self):
         """
-            Test the response of the disease detail endpoint
-            when disease is not found
+        Test the response of the disease detail endpoint
+        when disease is not found
         """
-        self.url_disease = reverse("disease_details", kwargs={"id": "CACNA1F-related Aland Island"})
+        self.url_disease = reverse(
+            "disease_details", kwargs={"id": "CACNA1F-related Aland Island"}
+        )
 
         response = self.client.get(self.url_disease)
 
         self.assertEqual(response.status_code, 404)
-        self.assertEqual(response.data["error"], "No matching Disease found for: CACNA1F-related Aland Island")
+        self.assertEqual(
+            response.data["error"],
+            "No matching Disease found for: CACNA1F-related Aland Island",
+        )
+
 
 class DiseaseSummaryTests(TestCase):
     """
-        Test the disease endpoint: DiseaseSummary
+    Test the disease endpoint: DiseaseSummary
     """
+
     fixtures = [
         "gene2phenotype_app/fixtures/disease.json",
         "gene2phenotype_app/fixtures/attribs.json",
@@ -60,19 +73,23 @@ class DiseaseSummaryTests(TestCase):
         "gene2phenotype_app/fixtures/locus.json",
         "gene2phenotype_app/fixtures/sequence.json",
         "gene2phenotype_app/fixtures/ontology_term.json",
-        "gene2phenotype_app/fixtures/source.json"
+        "gene2phenotype_app/fixtures/source.json",
     ]
 
     def test_get_disease(self):
         """
-            Test the response of the disease summary endpoint
+        Test the response of the disease summary endpoint
         """
-        self.url_disease = reverse("disease_summary", kwargs={"id": "CEP290-related JOUBERT SYNDROME TYPE 5"})
+        self.url_disease = reverse(
+            "disease_summary", kwargs={"id": "CEP290-related JOUBERT SYNDROME TYPE 5"}
+        )
 
         response = self.client.get(self.url_disease)
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data["disease"], "CEP290-related JOUBERT SYNDROME TYPE 5")
+        self.assertEqual(
+            response.data["disease"], "CEP290-related JOUBERT SYNDROME TYPE 5"
+        )
 
         expected_data = [
             {
@@ -83,19 +100,24 @@ class DiseaseSummaryTests(TestCase):
                 "variant_consequence": [None],
                 "variant_type": [],
                 "molecular_mechanism": "loss of function",
-                "stable_id": "G2P00001"
+                "stable_id": "G2P00001",
             }
         ]
         self.assertEqual(list(response.data["records_summary"]), expected_data)
 
     def test_not_found(self):
         """
-            Test the response of the disease summary endpoint
-            when disease is not found
+        Test the response of the disease summary endpoint
+        when disease is not found
         """
-        self.url_disease = reverse("disease_summary", kwargs={"id": "CACNA1F-related Aland Island"})
+        self.url_disease = reverse(
+            "disease_summary", kwargs={"id": "CACNA1F-related Aland Island"}
+        )
 
         response = self.client.get(self.url_disease)
 
         self.assertEqual(response.status_code, 404)
-        self.assertEqual(response.data["error"], "No matching Disease found for: CACNA1F-related Aland Island")
+        self.assertEqual(
+            response.data["error"],
+            "No matching Disease found for: CACNA1F-related Aland Island",
+        )

--- a/gene2phenotype_project/gene2phenotype_app/tests/views/test_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/views/test_disease.py
@@ -14,15 +14,46 @@ class DiseaseEndpointTests(TestCase):
         "gene2phenotype_app/fixtures/ontology_term.json",
     ]
 
+    def setUp(self):
+        self.url_disease = reverse(
+            "disease_details", kwargs={"id": "Congenital ichthyosis type 1"}
+        )
+        self.url_disease_mondo = reverse(
+            "disease_details", kwargs={"id": "MONDO:0009441"}
+        )
+        self.url_not_found = reverse(
+            "disease_details", kwargs={"id": "CACNA1F-related Aland Island"}
+        )
+        self.url_not_found_mondo = reverse(
+            "disease_details", kwargs={"id": "MONDO:0009442"}
+        )
+
     def test_get_disease(self):
         """
         Test the response of the disease detail endpoint
         """
-        self.url_disease = reverse(
-            "disease_details", kwargs={"id": "Congenital ichthyosis type 1"}
-        )
-
         response = self.client.get(self.url_disease)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["name"], "Congenital ichthyosis type 1")
+        self.assertEqual(response.data["last_updated"], None)
+        self.assertEqual(response.data["synonyms"], [])
+
+        expected_data = [
+            {
+                "accession": "MONDO:0009441",
+                "term": "MONDO:0009441",
+                "description": "Any autosomal recessive congenital ichthyosis in which the cause of the disease is a mutation in the TGM1 gene.",
+                "source": "Mondo",
+            }
+        ]
+        self.assertEqual(list(response.data["ontology_terms"]), expected_data)
+
+    def test_get_disease_by_mondo(self):
+        """
+        Test the response of the disease detail endpoint when searching by Mondo ID
+        """
+        response = self.client.get(self.url_disease_mondo)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["name"], "Congenital ichthyosis type 1")
@@ -44,16 +75,25 @@ class DiseaseEndpointTests(TestCase):
         Test the response of the disease detail endpoint
         when disease is not found
         """
-        self.url_disease = reverse(
-            "disease_details", kwargs={"id": "CACNA1F-related Aland Island"}
-        )
-
-        response = self.client.get(self.url_disease)
+        response = self.client.get(self.url_not_found)
 
         self.assertEqual(response.status_code, 404)
         self.assertEqual(
             response.data["error"],
             "No matching Disease found for: CACNA1F-related Aland Island",
+        )
+
+    def test_not_found_mondo(self):
+        """
+        Test the response of the disease detail endpoint
+        when disease is not found
+        """
+        response = self.client.get(self.url_not_found_mondo)
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(
+            response.data["error"],
+            "No matching Disease found for: MONDO:0009442",
         )
 
 

--- a/gene2phenotype_project/gene2phenotype_app/tests/views/test_gene.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/views/test_gene.py
@@ -1,19 +1,25 @@
 from django.test import TestCase
 from django.urls import reverse
 
+
 class GeneEndpointTests(TestCase):
     """
-        Test the gene endpoint: LocusGene
+    Test the gene endpoint: LocusGene
     """
-    fixtures = ["gene2phenotype_app/fixtures/locus.json", "gene2phenotype_app/fixtures/attribs.json",
-                "gene2phenotype_app/fixtures/source.json", "gene2phenotype_app/fixtures/sequence.json"]
+
+    fixtures = [
+        "gene2phenotype_app/fixtures/locus.json",
+        "gene2phenotype_app/fixtures/attribs.json",
+        "gene2phenotype_app/fixtures/source.json",
+        "gene2phenotype_app/fixtures/sequence.json",
+    ]
 
     def setUp(self):
         self.url_gene = reverse("locus_gene", kwargs={"name": "CEP290"})
 
     def test_get_gene(self):
         """
-            Test the response of the gene endpoint
+        Test the response of the gene endpoint
         """
         response = self.client.get(self.url_gene)
 
@@ -23,36 +29,44 @@ class GeneEndpointTests(TestCase):
         self.assertEqual(response.data["start"], 88049016)
         self.assertEqual(response.data["end"], 88142099)
 
-        expected_data_ids = {
-            "HGNC": "HGNC:29021",
-            "Ensembl": "ENSG00000198707"
-        }
+        expected_data_ids = {"HGNC": "HGNC:29021", "Ensembl": "ENSG00000198707"}
         self.assertEqual(response.data["ids"], expected_data_ids)
 
         expected_data_synonyms = ["BBS14", "CT87"]
         self.assertEqual(list(response.data["synonyms"]), expected_data_synonyms)
 
+
 class GeneSummaryEndpointTests(TestCase):
     """
-        Test the gene summary endpoint: LocusGeneSummary
+    Test the gene summary endpoint: LocusGeneSummary
     """
-    fixtures = ["gene2phenotype_app/fixtures/attribs.json", "gene2phenotype_app/fixtures/cv_molecular_mechanism.json",
-                "gene2phenotype_app/fixtures/disease.json", "gene2phenotype_app/fixtures/g2p_stable_id.json",
-                "gene2phenotype_app/fixtures/g2p_stable_id.json", "gene2phenotype_app/fixtures/cv_molecular_mechanism.json",
-                "gene2phenotype_app/fixtures/lgd_mechanism_evidence.json", "gene2phenotype_app/fixtures/lgd_mechanism_synopsis.json",
-                "gene2phenotype_app/fixtures/lgd_panel.json", "gene2phenotype_app/fixtures/locus_genotype_disease.json",
-                "gene2phenotype_app/fixtures/locus.json", "gene2phenotype_app/fixtures/publication.json",
-                "gene2phenotype_app/fixtures/sequence.json", "gene2phenotype_app/fixtures/user_panels.json",
-                "gene2phenotype_app/fixtures/ontology_term.json", "gene2phenotype_app/fixtures/source.json",
-                "gene2phenotype_app/fixtures/lgd_publication.json"
-                ]
+
+    fixtures = [
+        "gene2phenotype_app/fixtures/attribs.json",
+        "gene2phenotype_app/fixtures/cv_molecular_mechanism.json",
+        "gene2phenotype_app/fixtures/disease.json",
+        "gene2phenotype_app/fixtures/g2p_stable_id.json",
+        "gene2phenotype_app/fixtures/g2p_stable_id.json",
+        "gene2phenotype_app/fixtures/cv_molecular_mechanism.json",
+        "gene2phenotype_app/fixtures/lgd_mechanism_evidence.json",
+        "gene2phenotype_app/fixtures/lgd_mechanism_synopsis.json",
+        "gene2phenotype_app/fixtures/lgd_panel.json",
+        "gene2phenotype_app/fixtures/locus_genotype_disease.json",
+        "gene2phenotype_app/fixtures/locus.json",
+        "gene2phenotype_app/fixtures/publication.json",
+        "gene2phenotype_app/fixtures/sequence.json",
+        "gene2phenotype_app/fixtures/user_panels.json",
+        "gene2phenotype_app/fixtures/ontology_term.json",
+        "gene2phenotype_app/fixtures/source.json",
+        "gene2phenotype_app/fixtures/lgd_publication.json",
+    ]
 
     def setUp(self):
         self.url_gene_summary = reverse("locus_gene_summary", kwargs={"name": "CEP290"})
 
     def test_get_summary(self):
         """
-            Test the response of the gene summary endpoint
+        Test the response of the gene summary endpoint
         """
         response = self.client.get(self.url_gene_summary)
 
@@ -60,60 +74,78 @@ class GeneSummaryEndpointTests(TestCase):
 
         expected_data = [
             {
-                'disease': 'CEP290-related JOUBERT SYNDROME TYPE 5',
-                'genotype': 'biallelic_autosomal',
-                'confidence': 'definitive',
-                'panels': ['DD', 'Eye'],
-                'variant_consequence': [None],
-                'variant_type': [],
-                'molecular_mechanism': 'loss of function',
-                'last_updated': '2017-04-24',
-                'stable_id': 'G2P00001'
+                "disease": "CEP290-related JOUBERT SYNDROME TYPE 5",
+                "genotype": "biallelic_autosomal",
+                "confidence": "definitive",
+                "panels": ["DD", "Eye"],
+                "variant_consequence": [None],
+                "variant_type": [],
+                "molecular_mechanism": "loss of function",
+                "last_updated": "2017-04-24",
+                "stable_id": "G2P00001",
             }
         ]
         self.assertEqual(list(response.data["records_summary"]), expected_data)
 
+
 class GeneFunctionEndpointTests(TestCase):
     """
-        Test the gene function endpoint: GeneFunction
+    Test the gene function endpoint: GeneFunction
     """
-    fixtures = ["gene2phenotype_app/fixtures/locus.json", "gene2phenotype_app/fixtures/attribs.json",
-                "gene2phenotype_app/fixtures/source.json", "gene2phenotype_app/fixtures/sequence.json",
-                "gene2phenotype_app/fixtures/uniprot_annotation.json", "gene2phenotype_app/fixtures/gene_stats.json"]
+
+    fixtures = [
+        "gene2phenotype_app/fixtures/locus.json",
+        "gene2phenotype_app/fixtures/attribs.json",
+        "gene2phenotype_app/fixtures/source.json",
+        "gene2phenotype_app/fixtures/sequence.json",
+        "gene2phenotype_app/fixtures/uniprot_annotation.json",
+        "gene2phenotype_app/fixtures/gene_stats.json",
+    ]
 
     def setUp(self):
-        self.url_gene_function = reverse("locus_gene_function", kwargs={"name": "CEP290"})
+        self.url_gene_function = reverse(
+            "locus_gene_function", kwargs={"name": "CEP290"}
+        )
 
     def test_get_function(self):
         """
-            Test the response of the gene function endpoint
+        Test the response of the gene function endpoint
         """
         response = self.client.get(self.url_gene_function)
 
         self.assertEqual(response.status_code, 200)
 
         expected_data_function = {
-            'protein_function': 'Involved in early and late steps in cilia formation. Its association with CCP110 is required for inhibition of primary cilia formation by CCP110 (PubMed:18694559).',
-            'uniprot_accession': 'O15078'
+            "protein_function": "Involved in early and late steps in cilia formation. Its association with CCP110 is required for inhibition of primary cilia formation by CCP110 (PubMed:18694559).",
+            "uniprot_accession": "O15078",
         }
         self.assertEqual(response.data["function"], expected_data_function)
 
-        self.assertEqual(response.data["gene_stats"], {'gain_of_function_mp': 0.637})
+        self.assertEqual(response.data["gene_stats"], {"gain_of_function_mp": 0.637})
+
 
 class GeneDiseaseEndpointTests(TestCase):
     """
-        Test the gene disease endpoint: GeneDiseaseView
+    Test the gene disease endpoint: GeneDiseaseView
     """
-    fixtures = ["gene2phenotype_app/fixtures/locus.json", "gene2phenotype_app/fixtures/attribs.json",
-                "gene2phenotype_app/fixtures/source.json", "gene2phenotype_app/fixtures/sequence.json",
-                "gene2phenotype_app/fixtures/gene_disease.json"]
+
+    fixtures = [
+        "gene2phenotype_app/fixtures/locus.json",
+        "gene2phenotype_app/fixtures/attribs.json",
+        "gene2phenotype_app/fixtures/source.json",
+        "gene2phenotype_app/fixtures/sequence.json",
+        "gene2phenotype_app/fixtures/gene_disease.json",
+    ]
 
     def setUp(self):
         self.url_gene = reverse("locus_gene_disease", kwargs={"name": "CEP290"})
+        self.url_gene_synonym = reverse("locus_gene_disease", kwargs={"name": "BBS14"})
+        self.url_invalid_gene = reverse("locus_gene_disease", kwargs={"name": "BBBS14"})
+        self.url_not_found = reverse("locus_gene_disease", kwargs={"name": "GS2"})
 
     def test_get_gene(self):
         """
-            Test the response of the gene disease endpoint
+        Test the response of the gene disease endpoint
         """
         response = self.client.get(self.url_gene)
 
@@ -121,9 +153,88 @@ class GeneDiseaseEndpointTests(TestCase):
         self.assertEqual(response.data["count"], 4)
 
         expected_data_function = [
-            {'original_disease_name': 'JOUBERT SYNDROME 5', 'disease_name': 'joubert syndrome', 'identifier': '610188', 'source': 'OMIM'},
-            {'original_disease_name': 'SENIOR-LOKEN SYNDROME 6', 'disease_name': 'senior-loken syndrome', 'identifier': '610189', 'source': 'OMIM'},
-            {'original_disease_name': 'Joubert syndrome 5', 'disease_name': 'joubert syndrome', 'identifier': 'MONDO:0012432', 'source': 'Mondo'},
-            {'original_disease_name': 'Senior-Loken syndrome 6', 'disease_name': 'senior-loken syndrome', 'identifier': 'MONDO:0012433', 'source': 'Mondo'}
+            {
+                "original_disease_name": "JOUBERT SYNDROME 5",
+                "disease_name": "joubert syndrome",
+                "identifier": "610188",
+                "source": "OMIM",
+            },
+            {
+                "original_disease_name": "SENIOR-LOKEN SYNDROME 6",
+                "disease_name": "senior-loken syndrome",
+                "identifier": "610189",
+                "source": "OMIM",
+            },
+            {
+                "original_disease_name": "Joubert syndrome 5",
+                "disease_name": "joubert syndrome",
+                "identifier": "MONDO:0012432",
+                "source": "Mondo",
+            },
+            {
+                "original_disease_name": "Senior-Loken syndrome 6",
+                "disease_name": "senior-loken syndrome",
+                "identifier": "MONDO:0012433",
+                "source": "Mondo",
+            },
         ]
         self.assertEqual(response.data["results"], expected_data_function)
+
+    def test_get_gene_synonym(self):
+        """
+        Test the response of the gene disease endpoint when searching the gene synonym.
+        """
+        response = self.client.get(self.url_gene_synonym)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["count"], 4)
+
+        expected_data_function = [
+            {
+                "original_disease_name": "JOUBERT SYNDROME 5",
+                "disease_name": "joubert syndrome",
+                "identifier": "610188",
+                "source": "OMIM",
+            },
+            {
+                "original_disease_name": "SENIOR-LOKEN SYNDROME 6",
+                "disease_name": "senior-loken syndrome",
+                "identifier": "610189",
+                "source": "OMIM",
+            },
+            {
+                "original_disease_name": "Joubert syndrome 5",
+                "disease_name": "joubert syndrome",
+                "identifier": "MONDO:0012432",
+                "source": "Mondo",
+            },
+            {
+                "original_disease_name": "Senior-Loken syndrome 6",
+                "disease_name": "senior-loken syndrome",
+                "identifier": "MONDO:0012433",
+                "source": "Mondo",
+            },
+        ]
+        self.assertEqual(response.data["results"], expected_data_function)
+
+    def test_get_invalid_gene(self):
+        """
+        Test the response of the gene disease endpoint when searching for an invalid gene.
+        """
+        response = self.client.get(self.url_invalid_gene)
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.data["error"], "No matching Gene found for: BBBS14")
+
+    def test_not_found(self):
+        """
+        Test the response of the gene disease endpoint when no association found.
+        """
+        response = self.client.get(self.url_not_found)
+
+        self.assertEqual(response.status_code, 404)
+        print("->", response.data)
+        self.assertEqual(
+            response.data["error"],
+            "No matching Gene-Disease association found for: GS2",
+        )

--- a/gene2phenotype_project/gene2phenotype_app/tests/views/test_gene.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/views/test_gene.py
@@ -233,7 +233,6 @@ class GeneDiseaseEndpointTests(TestCase):
         response = self.client.get(self.url_not_found)
 
         self.assertEqual(response.status_code, 404)
-        print("->", response.data)
         self.assertEqual(
             response.data["error"],
             "No matching Gene-Disease association found for: GS2",

--- a/gene2phenotype_project/gene2phenotype_app/tests/views/test_panel.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/views/test_panel.py
@@ -28,7 +28,7 @@ class PanelListEndpointTests(TestCase):
         """
         response = self.client.get(self.url_panels)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data.get("count"), 3)
+        self.assertEqual(response.data.get("count"), 4)
 
     def test_login_get_panel_list(self):
         """
@@ -46,7 +46,7 @@ class PanelListEndpointTests(TestCase):
         response = self.client.get(self.url_panels)
         self.assertEqual(response.status_code, 200)
 
-        self.assertEqual(response.data.get("count"), 4)
+        self.assertEqual(response.data.get("count"), 5)
 
 
 class PanelDetailsEndpointTests(TestCase):

--- a/gene2phenotype_project/gene2phenotype_app/views/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/locus_genotype_disease.py
@@ -1356,19 +1356,14 @@ class LGDEditVariantTypeDescriptions(CustomPermissionAPIView):
 
 
 @extend_schema(exclude=True)
-class LGDEditComment(CustomPermissionAPIView):
+class LGDEditComment(APIView):
     """
     Add or delete a comment to a G2P record (LGD).
     """
 
     http_method_names = ["post", "patch", "options"]
     serializer_class = LGDCommentSerializer
-
-    # Define specific permissions
-    method_permissions = {
-        "post": [permissions.IsAuthenticated],
-        "patch": [permissions.IsAuthenticated, IsSuperUser],
-    }
+    permission_classes = [permissions.IsAuthenticated]
 
     def get_serializer_class(self, action):
         """
@@ -1481,6 +1476,7 @@ class LGDEditComment(CustomPermissionAPIView):
     def patch(self, request, stable_id):
         """
         This method deletes the LGD-comment.
+        This action is available to all authenticated users.
 
         Example: { "comment": "This is a comment" }
         """
@@ -1505,15 +1501,19 @@ class LGDEditComment(CustomPermissionAPIView):
             )
 
         try:
-            LGDComment.objects.filter(
+            lgd_comment = LGDComment.objects.get(
                 lgd=lgd_obj, comment=comment, is_deleted=0
-            ).update(is_deleted=1)
+            )
         except:
             return Response(
                 {"error": f"Cannot delete comment for ID '{stable_id}'"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
         else:
+            # Set comment to deleted
+            lgd_comment.is_deleted = 1
+            lgd_comment.save()
+            # Update the date of the last review
             lgd_obj.date_review = get_date_now()
             lgd_obj.save()
             return Response(

--- a/gene2phenotype_project/gene2phenotype_app/views/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/locus_genotype_disease.py
@@ -1506,7 +1506,7 @@ class LGDEditComment(APIView):
             )
         except:
             return Response(
-                {"error": f"Cannot delete comment for ID '{stable_id}'"},
+                {"error": f"Cannot delete comment for record '{stable_id}'"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
         else:
@@ -1517,7 +1517,7 @@ class LGDEditComment(APIView):
             lgd_obj.date_review = get_date_now()
             lgd_obj.save()
             return Response(
-                {"message": f"Comment successfully deleted for ID '{stable_id}'"},
+                {"message": f"Comment successfully deleted for record '{stable_id}'"},
                 status=status.HTTP_200_OK,
             )
 


### PR DESCRIPTION
### Description ###
Improve endpoint `lgd/<str:stable_id>/comment/`

- The view is updating the flag `is_deleted` using method `update()` - this does not trigger history row. In this PR the code is updated to call `save()` making sure the history table is updated.
- Update the permissions: all authenticated users can add/delete comments.
- Add unit tests

---

### JIRA Ticket ###
[G2P-575](https://embl.atlassian.net/browse/G2P-575)

---

### Contributor Checklist ###
- [x] The code compiles and runs as expected
- [x] Relevant unit tests are added or updated
- [x] All unit tests are passing
- [x] Code follows the [G2P Coding Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51871986/G2P+Coding+Guidelines)
- [x] Documentation (code comments, confluence, etc.) has been updated as needed

---

### Reviewer Checklist ###
Please **follow the [Code Review Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51937503/Code+Review+Guidelines)** when reviewing this PR.
- [ ] I have followed all review guidelines