### PR TITLE
Update lgd endpoint to return the lgd-comment primary key

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
@@ -424,6 +424,7 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
                 date = comment.date.strftime("%Y-%m-%d")
 
             text = {
+                "id": comment.id,
                 "text": comment.comment,
                 "date": date,
                 "is_public": comment.is_public,

--- a/gene2phenotype_project/gene2phenotype_app/tests/views/test_locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/views/test_locus_genotype_disease.py
@@ -54,6 +54,7 @@ class LocusGenotypeDiseaseDetailEndpoint(TestCase):
 
         expected_data_comments = [
             {
+                "id": 2,
                 "date": "2024-09-24",
                 "is_public": 1,
                 "text": "JLNS is due to altered gene product sequence",

--- a/gene2phenotype_project/gene2phenotype_app/views/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/locus_genotype_disease.py
@@ -1498,11 +1498,15 @@ class LGDEditComment(APIView):
         """
         This method deletes the LGD-comment.
         This action is available to all authenticated users.
-
-        Example: { "comment": "This is a comment" }
         """
-        comment = request.data.get("comment")
+        comment_id = request.data.get("comment_id", None)
         user = request.user
+
+        if not comment_id:
+            return Response(
+                {"error": f"Missing input key 'comment_id'"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         lgd_obj = get_object_or_404(
             LocusGenotypeDisease, stable_id__stable_id=stable_id, is_deleted=0
@@ -1523,7 +1527,7 @@ class LGDEditComment(APIView):
 
         try:
             lgd_comment = LGDComment.objects.get(
-                lgd=lgd_obj, comment=comment, is_deleted=0
+                lgd=lgd_obj, id=comment_id, is_deleted=0
             )
         except:
             return Response(


### PR DESCRIPTION
### Description ###

- Update the endpoint `gene2phenotype/api/lgd/<stable_id>` to return the lgd-comment id.
```
"comments": [
        {
            "id": 532,
            "text": "Pathogenic variants",
            "date": "2025-03-07",
            "is_public": 1
        }
    ]
```

- Update the endpoint `gene2phenotype/api/lgd/<stable_id>/comment/` to accept the comment id when deleting comments
To delete comment send the following:
`{"comment_id": 352}`

The web change is in the following PR: https://github.com/EBI-G2P/gene2phenotype_web/pull/150

---

### JIRA Ticket ###
No JIRA ticket

---

### Contributor Checklist ###
- [x] The code compiles and runs as expected
- [x] Relevant unit tests are added or updated
- [x] All unit tests are passing
- [x] Code follows the [G2P Coding Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51871986/G2P+Coding+Guidelines)
- [x] Documentation (code comments, confluence, etc.) has been updated as needed

---

### Reviewer Checklist ###
Please **follow the [Code Review Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51937503/Code+Review+Guidelines)** when reviewing this PR.
- [ ] I have followed all review guidelines