### PR TITLE
Return message for deleted records

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/tests/views/test_locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/views/test_locus_genotype_disease.py
@@ -44,9 +44,9 @@ class LocusGenotypeDiseaseDetailEndpoint(TestCase):
         Test calling the endpoint for a deleted record
         """
         response = self.client.get(self.url_lgd_deleted)
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 410)
         self.assertEqual(
-            response.data["error"], "No matching Entry found for: G2P00003"
+            response.data["message"], "G2P00003 is no longer available."
         )
 
     def test_lgd_invalid(self):

--- a/gene2phenotype_project/gene2phenotype_app/tests/views/test_search.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/views/test_search.py
@@ -183,9 +183,9 @@ class SearchTests(TestCase):
         url_search_id = f"{self.base_url_search}?type=stable_id&query=G2P00003"
         response = self.client.get(url_search_id)
 
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 410)
         self.assertEqual(
-            response.data["error"], "No matching stable_id found for: G2P00003"
+            response.data["message"], "G2P00003 is no longer available."
         )
 
     def test_search_g2p_id_merged(self):

--- a/gene2phenotype_project/gene2phenotype_app/views/base.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/base.py
@@ -28,10 +28,20 @@ class BaseView(generics.ListAPIView):
         return super().handle_exception(exc)
 
     def handle_merged_record(self, old_stable_id, new_stable_id):
+        """Method to return a message indicating the records has been merged"""
         return Response(
             {
                 "message": f"{old_stable_id} is no longer available. It has been merged into {new_stable_id}",
                 "stable_id": new_stable_id,
+            },
+            status=status.HTTP_410_GONE,
+        )
+
+    def handle_deleted_record(self, old_stable_id):
+        """Method to return a message indicating the records has been deleted"""
+        return Response(
+            {
+                "message": f"{old_stable_id} is no longer available."
             },
             status=status.HTTP_410_GONE,
         )
@@ -62,10 +72,20 @@ class BaseAPIView(APIView):
         return super().handle_exception(exc)
 
     def handle_merged_record(self, old_stable_id, new_stable_id):
+        """Method to return a message indicating the records has been merged"""
         return Response(
             {
                 "message": f"{old_stable_id} is no longer available. It has been merged into {new_stable_id}",
                 "stable_id": new_stable_id,
+            },
+            status=status.HTTP_410_GONE,
+        )
+    
+    def handle_deleted_record(self, old_stable_id):
+        """Method to return a message indicating the records has been deleted"""
+        return Response(
+            {
+                "message": f"{old_stable_id} is no longer available."
             },
             status=status.HTTP_410_GONE,
         )

--- a/gene2phenotype_project/gene2phenotype_app/views/search.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/search.py
@@ -430,7 +430,7 @@ class SearchView(BaseView):
         search_query = request.query_params.get("query", None)
         search_type = request.query_params.get("type", None)
 
-        # Check if query is a merged record
+        # Check if query is a merged or deleted record
         if search_type == "stable_id" or (
             search_query and search_query.startswith("G2P")
         ):
@@ -442,6 +442,9 @@ class SearchView(BaseView):
                 if g2p_obj.comment and g2p_obj.comment.startswith("Merged into"):
                     match = re.search(r"G2P\d{5,}", g2p_obj.comment)
                     return self.handle_merged_record(search_query, match.group())
+                else:
+                # No comment or comment with other description is considered to be simply deleted
+                    return self.handle_deleted_record(search_query)
 
         queryset = self.get_queryset()
         serializer = self.get_serializer_class()


### PR DESCRIPTION
### Description ###
Update the following endpoints to return a message for deleted records:

- `lgd/<stable_id>/`
- `search`

Similar to https://github.com/EBI-G2P/gene2phenotype_api/pull/232

Web change: https://github.com/EBI-G2P/gene2phenotype_web/pull/154

---

### JIRA Ticket ###
[G2P-589](https://embl.atlassian.net/browse/G2P-589)

---

### Contributor Checklist ###
- [x] The code compiles and runs as expected
- [x] Relevant unit tests are added or updated
- [x] All unit tests are passing
- [x] Code follows the [G2P Coding Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51871986/G2P+Coding+Guidelines)
- [x] Documentation (code comments, confluence, etc.) has been updated as needed

---

### Reviewer Checklist ###
Please **follow the [Code Review Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51937503/Code+Review+Guidelines)** when reviewing this PR.
- [ ] I have followed all review guidelines