### PR TITLE
G2P-550 - When adding publications, update status of linked mined publications

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/serializers/__init__.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/__init__.py
@@ -62,3 +62,5 @@ from .curation import CurationDataSerializer
 from .meta import MetaSerializer
 
 from .gencc_submission import CreateGenCCSubmissionSerializer, GenCCSubmissionSerializer
+
+from .mined_publication import LGDMinedPublicationSerializer

--- a/gene2phenotype_project/gene2phenotype_app/serializers/mined_publication.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/mined_publication.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from ..models import LGDMinedPublication
+from ..models import LGDMinedPublication, MinedPublication
 
 
 ### G2P record (LGD) - mined publication ###
@@ -14,6 +14,48 @@ class LGDMinedPublicationSerializer(serializers.ModelSerializer):
     title = serializers.CharField(source="mined_publication.title")
     status = serializers.CharField()
     comment = serializers.CharField()
+
+    def update_status_to_curated(self, lgd_obj, validated_data):
+        """
+        Method to only update the status of LGD mined publications to "curated".
+
+        'validated_data' example:
+            "publications": [{
+                        "publication": {
+                            "pmid": 32133637,
+                            "title": "First report of childhood progressive cerebellar atrophy due to compound heterozygous MTFMT variants.",
+                            "authors": "Bai R, Haude K, Yang E, Goldstein A, Anselm I.",
+                            "year": "2020",
+                        },
+                        "number_of_families": None,
+                        "consanguinity": None,
+                        "affected_individuals": None,
+                        "ancestry": None,
+                        "comments": [],
+                    }]
+        """
+        for publication in validated_data:
+            pmid = publication.get("publication").get("pmid")
+
+            # Check if the PMID exists in mined_publication table
+            try:
+                mined_publication_obj = MinedPublication.objects.get(pmid=pmid)
+            except MinedPublication.DoesNotExist:
+                # If the PMID does not exist then skip update
+                continue
+
+            # Check if the lgd - mined publication link already exists in lgd_mined_publication table
+            try:
+                lgd_mined_publication_obj = LGDMinedPublication.objects.get(
+                    lgd=lgd_obj, mined_publication=mined_publication_obj
+                )
+            except LGDMinedPublication.DoesNotExist:
+                # If the lgd - mined publication link does not exist then skip update
+                continue
+            else:
+                # If the lgd - mined publication link already exists then update status to "curated"
+                lgd_mined_publication_obj.status = "curated"
+                lgd_mined_publication_obj.save()
 
     class Meta:
         model = LGDMinedPublication

--- a/gene2phenotype_project/gene2phenotype_app/tests/insert_data/test_add_publications.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/insert_data/test_add_publications.py
@@ -12,6 +12,7 @@ from gene2phenotype_app.models import (
     LGDPhenotypeSummary,
     LGDVariantType,
     LGDVariantTypeDescription,
+    LGDMinedPublication,
 )
 
 
@@ -39,6 +40,8 @@ class LGDEditPublicationsEndpoint(TestCase):
         "gene2phenotype_app/fixtures/source.json",
         "gene2phenotype_app/fixtures/lgd_publication.json",
         "gene2phenotype_app/fixtures/lgd_publication_comment.json",
+        "gene2phenotype_app/fixtures/mined_publication.json",
+        "gene2phenotype_app/fixtures/lgd_mined_publication.json",
     ]
 
     def setUp(self):
@@ -198,6 +201,172 @@ class LGDEditPublicationsEndpoint(TestCase):
         self.assertEqual(len(lgd_variant_descriptions), 1)
         history_variant_descriptions = LGDVariantTypeDescription.history.all()
         self.assertEqual(len(history_variant_descriptions), 1)
+
+    def test_add_lgd_publication_linked_mined_publication(self):
+        """
+        Test the endpoint to add multiple publications to a record which also includes a linked mined publication.
+        It will test adding following 3 different publications:
+        1. Publication that is not present in mined publication table
+        2. Publication that is present in mined publication table but is not linked to this record
+        3. Publication that is present in mined publication table and is linked to this record
+        This test should add the 3 publications and should also update status of the 3rd mined publicationto "curated"
+        """
+        publication_to_add = {
+            "publications": [
+                {
+                    "publication": {"pmid": 15214012},
+                    "comment": {"comment": "", "is_public": 1},
+                    "families": {
+                        "families": 0,
+                        "consanguinity": "unknown",
+                        "ancestries": None,
+                        "affected_individuals": 0,
+                    },
+                },
+                {
+                    "publication": {"pmid": 32302040},
+                    "comment": {"comment": "", "is_public": 1},
+                    "families": {
+                        "families": 0,
+                        "consanguinity": "unknown",
+                        "ancestries": None,
+                        "affected_individuals": 0,
+                    },
+                },
+                {
+                    "publication": {"pmid": 7866404},
+                    "comment": {"comment": "", "is_public": 1},
+                    "families": {
+                        "families": 0,
+                        "consanguinity": "unknown",
+                        "ancestries": None,
+                        "affected_individuals": 0,
+                    },
+                },
+            ],
+            "phenotypes": [
+                {
+                    "pmid": "15214012",
+                    "summary": "Summary of phenotypes reported in PMID 15214012",
+                    "hpo_terms": [
+                        {
+                            "term": "Abnormality of connective tissue",
+                            "accession": "HP:0003549",
+                            "description": "",
+                        }
+                    ],
+                }
+            ],
+            "variant_types": [
+                {
+                    "comment": "",
+                    "de_novo": False,
+                    "inherited": False,
+                    "nmd_escape": False,
+                    "primary_type": "protein_changing",
+                    "secondary_type": "inframe_insertion",
+                    "supporting_papers": ["15214012"],
+                    "unknown_inheritance": True,
+                }
+            ],
+            "variant_descriptions": [
+                {"description": "HGVS:c.9Pro", "publication": "15214012"}
+            ],
+            "mechanism_synopsis": [{"name": "", "support": ""}],
+            "mechanism_evidence": [
+                {
+                    "pmid": "15214012",
+                    "description": "This is new evidence for the existing mechanism evidence.",
+                    "evidence_types": [
+                        {"primary_type": "Function", "secondary_type": ["Biochemical"]}
+                    ],
+                }
+            ],
+        }
+
+        # Initial status of the 3rd mined publication should be "mined"
+        lgd_mined_publications = LGDMinedPublication.objects.filter(
+            lgd__stable_id__stable_id="G2P00001", mined_publication__pmid=7866404
+        )
+        self.assertEqual(len(lgd_mined_publications), 1)
+        self.assertEqual(lgd_mined_publications[0].status, "mined")
+
+        # Login
+        user = User.objects.get(email="user5@test.ac.uk")
+        refresh = RefreshToken.for_user(user)
+        access_token = str(refresh.access_token)
+
+        # Authenticate by setting cookie on the test client
+        self.client.cookies[settings.SIMPLE_JWT["AUTH_COOKIE"]] = access_token
+
+        response = self.client.post(
+            self.url_add_publication,
+            publication_to_add,
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 201)
+
+        response_data = response.json()
+        self.assertEqual(
+            response_data["message"], "Publication added to the G2P entry successfully."
+        )
+
+        # Check inserted data and history tables
+        lgd_publications = LGDPublication.objects.filter(
+            lgd__stable_id__stable_id="G2P00001", is_deleted=0
+        )
+        self.assertEqual(len(lgd_publications), 4)
+        history_lgd_publications = LGDPublication.history.all()
+        self.assertEqual(len(history_lgd_publications), 3)
+
+        lgd_mechanism_evidence = LGDMolecularMechanismEvidence.objects.filter(
+            lgd__stable_id__stable_id="G2P00001", is_deleted=0
+        )
+        self.assertEqual(len(lgd_mechanism_evidence), 2)
+        history_mechanism_evidence = LGDMolecularMechanismEvidence.history.all()
+        self.assertEqual(len(history_mechanism_evidence), 1)
+
+        lgd_mechanism_synopsis = LGDMolecularMechanismSynopsis.objects.filter(
+            lgd__stable_id__stable_id="G2P00001", is_deleted=0
+        )
+        self.assertEqual(len(lgd_mechanism_synopsis), 1)
+        history_mechanism_synopsis = LGDMolecularMechanismSynopsis.history.all()
+        self.assertEqual(len(history_mechanism_synopsis), 0)  # there was no insertion
+
+        lgd_phenotypes = LGDPhenotype.objects.filter(
+            lgd__stable_id__stable_id="G2P00001", is_deleted=0
+        )
+        self.assertEqual(len(lgd_phenotypes), 2)
+        history_lgd_phenotypes = LGDPhenotype.history.all()
+        self.assertEqual(len(history_lgd_phenotypes), 1)
+
+        lgd_phenotype_summary = LGDPhenotypeSummary.objects.filter(
+            lgd__stable_id__stable_id="G2P00001", is_deleted=0
+        )
+        self.assertEqual(len(lgd_phenotype_summary), 1)
+        history_phenotype_summary = LGDPhenotypeSummary.history.all()
+        self.assertEqual(len(history_phenotype_summary), 1)
+
+        lgd_variant_types = LGDVariantType.objects.filter(
+            lgd__stable_id__stable_id="G2P00001", is_deleted=0
+        )
+        self.assertEqual(len(lgd_variant_types), 1)
+        history_lgd_variant_types = LGDVariantType.history.all()
+        self.assertEqual(len(history_lgd_variant_types), 1)
+
+        lgd_variant_descriptions = LGDVariantTypeDescription.objects.filter(
+            lgd__stable_id__stable_id="G2P00001", is_deleted=0
+        )
+        self.assertEqual(len(lgd_variant_descriptions), 1)
+        history_variant_descriptions = LGDVariantTypeDescription.history.all()
+        self.assertEqual(len(history_variant_descriptions), 1)
+
+        # Should update status of the 3rd mined publication to "curated"
+        lgd_mined_publications = LGDMinedPublication.objects.filter(
+            lgd__stable_id__stable_id="G2P00001", mined_publication__pmid=7866404
+        )
+        self.assertEqual(len(lgd_mined_publications), 1)
+        self.assertEqual(lgd_mined_publications[0].status, "curated")
 
     def test_add_lgd_publication_wrong_mechanism_evidence(self):
         """


### PR DESCRIPTION
### Description ###
Extension to` /gene2phenotype/api/lgd/<stable_id>/publication/` endpoint.
When adding publications to existing record, we need to update status of the linked mined publications to "curated".

One of the changes as part of extending endpoints for mined publications ([G2P-550](https://embl.atlassian.net/browse/G2P-550)).

---

### JIRA Ticket ###
[G2P-550](https://embl.atlassian.net/browse/G2P-550)

---

### Contributor Checklist ###
- [x] The code compiles and runs as expected
- [x] Relevant unit tests are added or updated
- [x] All unit tests are passing
- [x] Code follows the [G2P Coding Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51871986/G2P+Coding+Guidelines)
- [x] Documentation (code comments, confluence, etc.) has been updated as needed

---

### Reviewer Checklist ###
Please **follow the [Code Review Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51937503/Code+Review+Guidelines)** when reviewing this PR.
- [ ] I have followed all review guidelines