### PR TITLE
Endpoint update disease to support synonyms

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/fixtures/disease_synonym.json
+++ b/gene2phenotype_project/gene2phenotype_app/fixtures/disease_synonym.json
@@ -1,0 +1,10 @@
+[
+    {
+        "model": "gene2phenotype_app.diseasesynonym",
+        "pk": 1,
+        "fields": {
+            "synonym": "CONGENITAL DISORDERS OF GLYCOSYLATION TYPE 1",
+            "disease": 1
+        }
+    }
+]


### PR DESCRIPTION
### Description ###
Update endpoint: `gene2phenotype/api/update/diseases/` to accept an optional value `add_synonym`. This allows to add the previous disease name as a synonym.

Example: Update the disease_id `2101` to the new name `SUFU-related medulloblastoma, associated with Gorlin syndrome` and add the current name as a synonym.
```
{
  "id": 2101,
  "name": "SUFU-related medulloblastoma, associated with Gorlin syndrome",
  "add_synonym": True
}
```

---

### JIRA Ticket ###
Part of [G2P-545](https://embl.atlassian.net/browse/G2P-545)

---

### Contributor Checklist ###
- [x] The code compiles and runs as expected
- [x] Relevant unit tests are added or updated
- [x] All unit tests are passing
- [x] Code follows the [G2P Coding Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51871986/G2P+Coding+Guidelines)
- [x] Documentation (code comments, confluence, etc.) has been updated as needed

---

### Reviewer Checklist ###
Please **follow the [Code Review Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51937503/Code+Review+Guidelines)** when reviewing this PR.
- [ ] I have followed all review guidelines