### PR TITLE
Fix bug in gene, disease and panel summary

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/fixtures/lgd_variant_type.json
+++ b/gene2phenotype_project/gene2phenotype_app/fixtures/lgd_variant_type.json
@@ -37,5 +37,18 @@
             "publication": 1,
             "is_deleted": 0
         }
+    },
+    {
+        "model": "gene2phenotype_app.lgdvarianttype",
+        "pk": 4,
+        "fields": {
+            "lgd": 2,
+            "variant_type_ot": 24,
+            "inherited": false,
+            "de_novo": false,
+            "unknown_inheritance": false,
+            "publication": 2,
+            "is_deleted": 1
+        }
     }
 ]

--- a/gene2phenotype_project/gene2phenotype_app/serializers/disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/disease.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from django.db.models import Q
 from typing import Any, Optional
 from datetime import date
 import re
@@ -184,7 +185,17 @@ class DiseaseDetailSerializer(DiseaseSerializer):
         """
         if user.is_authenticated:
             lgd_select = (
-                LocusGenotypeDisease.objects.filter(disease=id, is_deleted=0)
+                LocusGenotypeDisease.objects.filter(
+                    disease=id,
+                    is_deleted=0,
+                    lgdpanel__is_deleted=0,
+                )
+                .filter(
+                    Q(lgdvariantgenccconsequence__is_deleted=0) |
+                    Q(lgdvariantgenccconsequence__isnull=True),
+                    Q(lgdvarianttype__is_deleted=0) |
+                    Q(lgdvarianttype__isnull=True),
+                )
                 .select_related("locus", "genotype", "confidence", "mechanism")
                 .prefetch_related(
                     "lgd_panel",
@@ -199,7 +210,16 @@ class DiseaseDetailSerializer(DiseaseSerializer):
         else:
             lgd_select = (
                 LocusGenotypeDisease.objects.filter(
-                    disease=id, is_deleted=0, lgdpanel__panel__is_visible=1
+                    disease=id,
+                    is_deleted=0,
+                    lgdpanel__panel__is_visible=1,
+                    lgdpanel__is_deleted=0,
+                )
+                .filter(
+                    Q(lgdvariantgenccconsequence__is_deleted=0) |
+                    Q(lgdvariantgenccconsequence__isnull=True),
+                    Q(lgdvarianttype__is_deleted=0) |
+                    Q(lgdvarianttype__isnull=True),
                 )
                 .select_related("locus", "genotype", "confidence", "mechanism")
                 .prefetch_related(

--- a/gene2phenotype_project/gene2phenotype_app/serializers/panel.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/panel.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from django.db import IntegrityError
+from django.db.models import Q
 from typing import Optional
 from datetime import date
 
@@ -159,7 +160,18 @@ class PanelDetailSerializer(serializers.ModelSerializer):
         """
         if user.is_authenticated:
             lgd_panels_selected = (
-                LGDPanel.objects.select_related(
+                LGDPanel.objects.filter(
+                    panel=panel.id,
+                    is_deleted=0,
+                    lgd__is_deleted=0,
+                )
+                .filter(
+                    Q(lgd__lgdvariantgenccconsequence__is_deleted=0) |
+                    Q(lgd__lgdvariantgenccconsequence__isnull=True),
+                    Q(lgd__lgdvarianttype__is_deleted=0) |
+                    Q(lgd__lgdvarianttype__isnull=True),
+                )
+                .select_related(
                     "lgd",
                     "lgd__locus",
                     "lgd__disease",
@@ -171,12 +183,20 @@ class PanelDetailSerializer(serializers.ModelSerializer):
                     "lgd__lgd_variant_gencc_consequence", "lgd__lgd_variant_type"
                 )
                 .order_by("-lgd__date_review")
-                .filter(panel=panel.id, is_deleted=0, lgd__is_deleted=0)
             )
         else:
             lgd_panels_selected = (
                 LGDPanel.objects.filter(
-                    panel=panel.id, is_deleted=0, lgd__is_deleted=0, panel__is_visible=1
+                    panel=panel.id,
+                    is_deleted=0,
+                    lgd__is_deleted=0,
+                    panel__is_visible=1,
+                )
+                .filter(
+                    Q(lgd__lgdvariantgenccconsequence__is_deleted=0) |
+                    Q(lgd__lgdvariantgenccconsequence__isnull=True),
+                    Q(lgd__lgdvarianttype__is_deleted=0) |
+                    Q(lgd__lgdvarianttype__isnull=True),
                 )
                 .select_related(
                     "lgd",

--- a/gene2phenotype_project/gene2phenotype_app/tests/delete_data/test_delete_lgd_publication.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/delete_data/test_delete_lgd_publication.py
@@ -233,7 +233,7 @@ class LGDDeletePublication(TestCase):
             publication__pmid=15214012,
             is_deleted=1,
         )
-        self.assertEqual(len(lgd_variant_type), 2)
+        self.assertEqual(len(lgd_variant_type), 3)
 
         lgd_variant_description = LGDVariantTypeDescription.objects.filter(
             lgd__stable_id__stable_id="G2P00002",

--- a/gene2phenotype_project/gene2phenotype_app/tests/delete_data/test_delete_lgd_variant_type.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/delete_data/test_delete_lgd_variant_type.py
@@ -191,7 +191,7 @@ class LGDEditVariantTypesEndpoint(TestCase):
         lgd_deleted_variants = LGDVariantType.objects.filter(
             lgd__stable_id__stable_id="G2P00002", is_deleted=1
         )
-        self.assertEqual(len(lgd_deleted_variants), 1)
+        self.assertEqual(len(lgd_deleted_variants), 2)
 
         # Check remaining LGD-variant types
         lgd_variants = LGDVariantType.objects.filter(

--- a/gene2phenotype_project/gene2phenotype_app/tests/views/test_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/views/test_disease.py
@@ -107,7 +107,11 @@ class DiseaseSummaryTests(TestCase):
         "gene2phenotype_app/fixtures/attribs.json",
         "gene2phenotype_app/fixtures/cv_molecular_mechanism.json",
         "gene2phenotype_app/fixtures/g2p_stable_id.json",
+        "gene2phenotype_app/fixtures/publication.json",
         "gene2phenotype_app/fixtures/lgd_panel.json",
+        "gene2phenotype_app/fixtures/lgd_publication.json",
+        "gene2phenotype_app/fixtures/lgd_variant_type.json",
+        "gene2phenotype_app/fixtures/lgd_variant_consequence.json",
         "gene2phenotype_app/fixtures/user_panels.json",
         "gene2phenotype_app/fixtures/locus_genotype_disease.json",
         "gene2phenotype_app/fixtures/locus.json",
@@ -144,6 +148,33 @@ class DiseaseSummaryTests(TestCase):
             }
         ]
         self.assertEqual(list(response.data["records_summary"]), expected_data)
+
+    def test_get_disease_complete(self):
+        """
+        Test the response of the disease summary endpoint with deleted variants in the output
+        """
+        self.url_disease = reverse(
+            "disease_summary", kwargs={"id": "RAB27A-related Griscelli syndrome"}
+        )
+
+        response = self.client.get(self.url_disease)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data["disease"], "RAB27A-related Griscelli syndrome"
+        )
+
+        expected_data = {
+            "locus": "RAB27A",
+            "genotype": "biallelic_autosomal",
+            "confidence": "definitive",
+            "panels": ["Cardiac"],
+            "variant_consequence": ["absent gene product"],
+            "variant_type": ['inframe_insertion', 'intron_variant'],
+            "molecular_mechanism": "loss of function",
+            "stable_id": "G2P00002",
+        }
+        self.assertEqual(list(response.data["records_summary"])[0], expected_data)
 
     def test_not_found(self):
         """

--- a/gene2phenotype_project/gene2phenotype_app/tests/views/test_gene.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/views/test_gene.py
@@ -57,10 +57,13 @@ class GeneSummaryEndpointTests(TestCase):
         "gene2phenotype_app/fixtures/ontology_term.json",
         "gene2phenotype_app/fixtures/source.json",
         "gene2phenotype_app/fixtures/lgd_publication.json",
+        "gene2phenotype_app/fixtures/lgd_variant_type.json",
+        "gene2phenotype_app/fixtures/lgd_variant_consequence.json",
     ]
 
     def setUp(self):
         self.url_gene_summary = reverse("locus_gene_summary", kwargs={"name": "CEP290"})
+        self.url_gene_summary_2 = reverse("locus_gene_summary", kwargs={"name": "RAB27A"})
 
     def test_get_summary(self):
         """
@@ -85,6 +88,28 @@ class GeneSummaryEndpointTests(TestCase):
         ]
         self.assertEqual(list(response.data["records_summary"]), expected_data)
 
+    def test_get_summary_complete(self):
+        """
+        Test the response of the gene summary endpoint when there are
+        deleted variants in the record
+        """
+        response = self.client.get(self.url_gene_summary_2)
+
+        self.assertEqual(response.status_code, 200)
+
+        # The output is sorted by date of review
+        expected_data = {
+                "disease": "RAB27A-related Griscelli syndrome",
+                "genotype": "biallelic_autosomal",
+                "confidence": "definitive",
+                "panels": ["Cardiac"],
+                "variant_consequence": ["absent gene product"],
+                "variant_type": ['inframe_insertion', 'intron_variant'],
+                "molecular_mechanism": "loss of function",
+                "last_updated": "2018-07-05",
+                "stable_id": "G2P00002",
+            }
+        self.assertEqual(list(response.data["records_summary"])[1], expected_data)
 
 class GeneFunctionEndpointTests(TestCase):
     """

--- a/gene2phenotype_project/gene2phenotype_app/tests/views/test_panel.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/views/test_panel.py
@@ -117,23 +117,39 @@ class PanelSummaryEndpointTests(TestCase):
         "gene2phenotype_app/fixtures/locus.json",
         "gene2phenotype_app/fixtures/sequence.json",
         "gene2phenotype_app/fixtures/disease.json",
+        "gene2phenotype_app/fixtures/publication.json",
         "gene2phenotype_app/fixtures/ontology_term.json",
         "gene2phenotype_app/fixtures/source.json",
         "gene2phenotype_app/fixtures/locus_genotype_disease.json",
         "gene2phenotype_app/fixtures/lgd_panel.json",
+        "gene2phenotype_app/fixtures/lgd_publication.json",
+        "gene2phenotype_app/fixtures/lgd_variant_type.json",
+        "gene2phenotype_app/fixtures/lgd_variant_consequence.json",
         "gene2phenotype_app/fixtures/cv_molecular_mechanism.json",
     ]
 
     def setUp(self):
-        self.url_panels = reverse("panel_summary", kwargs={"name": "DD"})
+        self.url_panel_dd = reverse("panel_summary", kwargs={"name": "DD"})
+        self.url_panel_cardiac = reverse("panel_summary", kwargs={"name": "Cardiac"})
 
-    def test_get_panel_summary(self):
+    def test_get_dd_panel_summary(self):
         """
         Get the summary for a visible panel.
         """
-        response = self.client.get(self.url_panels)
+        response = self.client.get(self.url_panel_dd)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data.get("records_summary")), 1)
+    
+    def test_get_cardiac_panel_summary(self):
+        """
+        Get the summary for a visible panel.
+        """
+        response = self.client.get(self.url_panel_cardiac)
+        self.assertEqual(response.status_code, 200)
+        records_summary = response.data.get("records_summary")
+        self.assertEqual(len(records_summary), 1)
+        self.assertEqual(len(list(records_summary)[0]["variant_type"]), 2)
+        self.assertEqual(len(list(records_summary)[0]["variant_consequence"]), 1)
 
 
 class PanelDownloadEndpointTests(TestCase):


### PR DESCRIPTION
### Description ###

**Affected endpoints**
- https://www.ebi.ac.uk/gene2phenotype/api/gene/HK1/summary/
- https://www.ebi.ac.uk/gene2phenotype/api/disease/HK1-related%20neurodevelopmental%20disorder%20with%20visual%20defects%20and%20brain%20anomalies/summary/
- https://www.ebi.ac.uk/gene2phenotype/api/panel/DD/summary/

The endpoints return all variant types and variant consequences even if they are deleted.
This PR fixes the queries to only returns variants if they are not deleted (is_deleted=0).

> [!IMPORTANT]
> This PR is going to be added has a post-release fix (v10) 

---

### JIRA Ticket ###
No ticket

---

### Contributor Checklist ###
- [x] The code compiles and runs as expected
- [x] Relevant unit tests are added or updated
- [x] All unit tests are passing
- [x] Code follows the [G2P Coding Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51871986/G2P+Coding+Guidelines)
- [x] Documentation (code comments, confluence, etc.) has been updated as needed

---

### Reviewer Checklist ###
Please **follow the [Code Review Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51937503/Code+Review+Guidelines)** when reviewing this PR.
- [ ] I have followed all review guidelines