### PR TITLE
Storing password reset tokens for audit and logging reasons

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/models.py
+++ b/gene2phenotype_project/gene2phenotype_app/models.py
@@ -949,4 +949,17 @@ class LGDMutationConsequenceFlag(models.Model):
     class Meta:
         db_table = "lgd_mutation_consequence_flag"
 
+class PasswordResetToken(models.Model):
+    id = models.AutoField(primary_key=True)
+    user = models.ForeignKey("User", on_delete=models.PROTECT)
+    token_hash = models.CharField(max_length=255, null=False, unique=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    expires_at = models.DateTimeField(null=False)
+    used = models.BooleanField(default=False)
+    used_at = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        db_table = "password_reset_token"
+        indexes = [models.Index(fields=["token"])]
+
 ###################

--- a/gene2phenotype_project/gene2phenotype_app/serializers/user.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/user.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
 from django.contrib.auth import authenticate
+from django.conf import settings
 from django.contrib.auth.tokens import PasswordResetTokenGenerator
 from django.utils.encoding import smart_str, force_bytes
 from rest_framework.exceptions import AuthenticationFailed
@@ -10,8 +11,8 @@ from django.contrib.auth.models import update_last_login
 from django.core.exceptions import ObjectDoesNotExist
 
 
-from ..utils import CustomMail
-from ..models import User, UserPanel, Panel
+from ..utils import CustomMail, retrieve_hashed_token
+from ..models import User, UserPanel, Panel, PasswordResetToken
 
 
 class UserSerializer(serializers.ModelSerializer):
@@ -535,6 +536,10 @@ class VerifyEmailSerializer(serializers.ModelSerializer):
                 reset_link=reset_link,
                 to_email=user.email,
             )
+            hashed_token = retrieve_hashed_token(self, reset_token)
+            token_lifetime = getattr(settings, "PASSWORD_RESET_TIMEOUT", 900) # default to 15 minutes if not set
+            expiry_time = timezone.now() + timedelta(seconds=token_lifetime)
+            PasswordResetToken.objects.create(user=user, token_hash=hashed_token, used=False, expires_at=expiry_time)
             return {"id": user.id, "email": user.email, "token": reset_token}
         else:
             # If user not found, return a generic response to avoid user enumeration
@@ -598,9 +603,12 @@ class PasswordResetSerializer(serializers.ModelSerializer):
         uid = smart_str(urlsafe_base64_decode(uid))
         user = User.objects.get(id=uid)
 
-        if not PasswordResetTokenGenerator().check_token(user, token):
+        # checks the validation of the token against the time set in settings and if token is used or not
+        if self.check_token_validity(token):
             raise serializers.ValidationError("Token is not valid or expired")
 
+        # if the token is valid, mark the token as used to prevent reuse
+        self.update_password_reset_token(token)
         attrs["id"] = uid
 
         return attrs
@@ -625,6 +633,47 @@ class PasswordResetSerializer(serializers.ModelSerializer):
         user.save()
 
         return user.email
+
+    def update_password_reset_token(self, token: str):
+        """
+        Update the password reset token as used
+
+        Args:
+            token (str): The token to be updated
+
+        Method:
+            Updates the PasswordResetToken object associated with the token to mark it as used
+        """
+        hashed_token = retrieve_hashed_token(self, token)
+        reset_token = PasswordResetToken.objects.filter(token_hash=hashed_token).first()
+        if reset_token:
+            reset_token.used = True
+            reset_token.used_at = timezone.now()
+            reset_token.save()
+
+
+    def check_token_validity(self, token: str) -> bool:
+        """
+        Verify that:
+        - Django's token generator considers the token valid for the given user (time/state)
+        - there is a matching PasswordResetToken DB row that is unused
+
+        Args:
+            token (str): The token to be checked
+
+        Returns:
+            bool: True if the token is valid and not expired, False otherwise
+        """
+        if not PasswordResetTokenGenerator().check_token(user, token):
+            return False
+        hashed_token = retrieve_hashed_token(self, token)
+        reset_token = PasswordResetToken.objects.filter(token_hash=hashed_token, used=False).first()
+        # Check if the token is within the valid time frame
+        if not reset_token:
+            return False
+        if timezone.now() > reset_token.expires_at:
+            return False
+        return True
 
     class Meta:
         model = User

--- a/gene2phenotype_project/gene2phenotype_app/tests/views/test_user.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/views/test_user.py
@@ -381,6 +381,28 @@ class ResetPasswordTest(TestCase):
 
         self.assertEqual(response.status_code, 400)
 
+    def test_reset_password_check_token_valid(self):
+        uid = urlsafe_base64_encode(force_bytes(self.user.id))
+        token = PasswordResetTokenGenerator().make_token(self.user)
+        response = self.client.post(
+            reverse("reset_password", kwargs={"uid": uid, "token": token}),
+            {"password": "new_password1", "password2": "new_password1"},
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 201)
+
+    def test_check_token_fails_for_tampered_token(self):
+        uid = urlsafe_base64_encode(force_bytes(self.user.id))
+        token = PasswordResetTokenGenerator().make_token(self.user)
+        tampered_token = token + "tampered"
+        response = self.client.post(
+            reverse("reset_password", kwargs={"uid": uid, "token": tampered_token}),
+            {"password": "new_password1", "password2": "new_password1"},
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400)
 
 class UserAdminPermissionTest(TestCase):
     fixtures = ["gene2phenotype_app/fixtures/user_panels.json"]

--- a/gene2phenotype_project/gene2phenotype_app/utils/__init__.py
+++ b/gene2phenotype_project/gene2phenotype_app/utils/__init__.py
@@ -10,7 +10,7 @@ from .disease_utils import (
 from .publication_utils import get_publication, get_authors, clean_title
 from .locus_utils import validate_gene
 from .phenotype_utils import validate_phenotype
-from .user_utils import CustomMail
+from .user_utils import CustomMail, retrieve_hashed_token
 from .date_utils import get_date_now
 from .curationinfo_utils import ConfidenceCustomMail
 from .lgd_utils import (

--- a/gene2phenotype_project/gene2phenotype_app/utils/user_utils.py
+++ b/gene2phenotype_project/gene2phenotype_app/utils/user_utils.py
@@ -65,7 +65,7 @@ class CustomMail:
         except Exception as e:
             return str(e)
 
-def retrieve_hashed_token(self, token: str) -> str:
+def retrieve_hashed_token(token: str) -> str:
     """
     Retrieve the hashed version of the token
 

--- a/gene2phenotype_project/gene2phenotype_app/utils/user_utils.py
+++ b/gene2phenotype_project/gene2phenotype_app/utils/user_utils.py
@@ -1,3 +1,4 @@
+import hashlib
 from email.message import EmailMessage
 from smtplib import SMTP
 from django.conf import settings
@@ -63,3 +64,15 @@ class CustomMail:
                 server.send_message(message)
         except Exception as e:
             return str(e)
+
+def retrieve_hashed_token(self, token: str) -> str:
+    """
+    Retrieve the hashed version of the token
+
+    Args:
+        token (str): The token to be hashed
+
+    Returns:
+        str: The hashed version of the token
+    """
+    return hashlib.sha256(token.encode()).hexdigest()

--- a/gene2phenotype_project/gene2phenotype_project/settings.py
+++ b/gene2phenotype_project/gene2phenotype_project/settings.py
@@ -71,6 +71,8 @@ LOGGING = {
     },
 }
 
+PASSWORD_RESET_TIMEOUT = 900
+
 INSTALLED_APPS = [
     "django.contrib.admin",
     "django.contrib.auth",


### PR DESCRIPTION
### Description ###

Following the principles suggested [here](https://cheatsheetseries.owasp.org/cheatsheets/Forgot_Password_Cheat_Sheet.html), I think storing the password reset tokens might be a good way for auditing and more secure reasons.
---

### JIRA Ticket ###
----

---

### Contributor Checklist ###
- [ ] The code compiles and runs as expected
- [ ] Relevant unit tests are added or updated
- [ ] All unit tests are passing
- [ ] Code follows the [G2P Coding Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51871986/G2P+Coding+Guidelines)
- [ ] Documentation (code comments, confluence, etc.) has been updated as needed

---

### Reviewer Checklist ###
Please **follow the [Code Review Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51937503/Code+Review+Guidelines)** when reviewing this PR.
- [ ] I have followed all review guidelines