### PR TITLE
Return the uniprot subunit structure data

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/fixtures/uniprot_annotation.json
+++ b/gene2phenotype_project/gene2phenotype_app/fixtures/uniprot_annotation.json
@@ -5,9 +5,31 @@
         "fields": {
             "uniprot_accession": "O15078",
             "gene": 1,
-            "protein_function": "Involved in early and late steps in cilia formation. Its association with CCP110 is required for inhibition of primary cilia formation by CCP110 (PubMed:18694559).",
+            "annotation": "Involved in early and late steps in cilia formation. Its association with CCP110 is required for inhibition of primary cilia formation by CCP110 (PubMed:18694559).",
             "source": 8,
             "data_type": 65
+        }
+    },
+    {
+        "model": "gene2phenotype_app.uniprotannotation",
+        "pk": 2,
+        "fields": {
+            "uniprot_accession": "P51159",
+            "gene": 2,
+            "annotation": "The small GTPases Rab are key regulators of intracellular membrane trafficking, from the formation of transport vesicles to their fusion with membranes. Rabs cycle between an inactive GDP-bound form and an active GTP-bound form that is able to recruit to membranes different sets of downstream effectors directly responsible for vesicle formation, movement, tethering and fusion (PubMed:30771381). RAB27A regulates homeostasis of late endocytic pathway, including endosomal positioning, maturation and secretion (PubMed:30771381). Plays a role in cytotoxic granule exocytosis in lymphocytes. Required for both granule maturation and granule docking and priming at the immunologic synapse (PubMed:18812475)",
+            "source": 8,
+            "data_type": 65
+        }
+    },
+    {
+        "model": "gene2phenotype_app.uniprotannotation",
+        "pk": 3,
+        "fields": {
+            "uniprot_accession": "P51159",
+            "gene": 2,
+            "annotation": "Does not interact with the BLOC-3 complex (heterodimer of HPS1 and HPS4) (PubMed:20048159).",
+            "source": 8,
+            "data_type": 66
         }
     }
 ]

--- a/gene2phenotype_project/gene2phenotype_app/migrations/0020_remove_uniprotannotation_uniprot_ann_uniprot_c49c17_idx_and_more.py
+++ b/gene2phenotype_project/gene2phenotype_app/migrations/0020_remove_uniprotannotation_uniprot_ann_uniprot_c49c17_idx_and_more.py
@@ -31,6 +31,11 @@ class Migration(migrations.Migration):
             model_name="uniprotannotation",
             name="mim",
         ),
+        migrations.RenameField(
+            model_name="uniprotannotation",
+            old_name="protein_function",
+            new_name="annotation",
+        ),
         migrations.AddField(
             model_name="uniprotannotation",
             name="data_type",

--- a/gene2phenotype_project/gene2phenotype_app/models.py
+++ b/gene2phenotype_project/gene2phenotype_app/models.py
@@ -703,7 +703,7 @@ class UniprotAnnotation(models.Model):
     id = models.AutoField(primary_key=True)
     uniprot_accession = models.CharField(max_length=100, null=False)
     gene = models.ForeignKey("Locus", on_delete=models.PROTECT)
-    protein_function = models.TextField(null=False)
+    annotation = models.TextField(null=False)
     data_type = models.ForeignKey("Attrib", on_delete=models.PROTECT)
     source = models.ForeignKey("Source", on_delete=models.PROTECT)
 

--- a/gene2phenotype_project/gene2phenotype_app/serializers/locus.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/locus.py
@@ -239,8 +239,27 @@ class LocusGeneSerializer(LocusSerializer):
         )
 
         for function_obj in uniprot_annotation_objs:
-            result_data["protein_function"] = function_obj.protein_function
+            result_data["protein_function"] = function_obj.annotation
             result_data["uniprot_accession"] = function_obj.uniprot_accession
+
+        return result_data
+
+    def subunit_structure(self):
+        """
+        Returns the subunit structure from UniProt.
+
+        Returns:
+                (dict) result_data: it includes the subunit quaternary structure and the uniprot accession
+        """
+        result_data = {}
+        uniprot_annotation_objs = UniprotAnnotation.objects.filter(
+            gene=self.id,
+            data_type__value="uniprot_subunit",
+        )
+
+        for data_obj in uniprot_annotation_objs:
+            result_data["quaternary_structure"] = data_obj.annotation
+            result_data["uniprot_accession"] = data_obj.uniprot_accession
 
         return result_data
 

--- a/gene2phenotype_project/gene2phenotype_app/tests/views/test_gene.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/views/test_gene.py
@@ -63,7 +63,9 @@ class GeneSummaryEndpointTests(TestCase):
 
     def setUp(self):
         self.url_gene_summary = reverse("locus_gene_summary", kwargs={"name": "CEP290"})
-        self.url_gene_summary_2 = reverse("locus_gene_summary", kwargs={"name": "RAB27A"})
+        self.url_gene_summary_2 = reverse(
+            "locus_gene_summary", kwargs={"name": "RAB27A"}
+        )
 
     def test_get_summary(self):
         """
@@ -99,17 +101,18 @@ class GeneSummaryEndpointTests(TestCase):
 
         # The output is sorted by date of review
         expected_data = {
-                "disease": "RAB27A-related Griscelli syndrome",
-                "genotype": "biallelic_autosomal",
-                "confidence": "definitive",
-                "panels": ["Cardiac"],
-                "variant_consequence": ["absent gene product"],
-                "variant_type": ['inframe_insertion', 'intron_variant'],
-                "molecular_mechanism": "loss of function",
-                "last_updated": "2018-07-05",
-                "stable_id": "G2P00002",
-            }
+            "disease": "RAB27A-related Griscelli syndrome",
+            "genotype": "biallelic_autosomal",
+            "confidence": "definitive",
+            "panels": ["Cardiac"],
+            "variant_consequence": ["absent gene product"],
+            "variant_type": ["inframe_insertion", "intron_variant"],
+            "molecular_mechanism": "loss of function",
+            "last_updated": "2018-07-05",
+            "stable_id": "G2P00002",
+        }
         self.assertEqual(list(response.data["records_summary"])[1], expected_data)
+
 
 class GeneFunctionEndpointTests(TestCase):
     """
@@ -129,6 +132,9 @@ class GeneFunctionEndpointTests(TestCase):
         self.url_gene_function = reverse(
             "locus_gene_function", kwargs={"name": "CEP290"}
         )
+        self.url_gene_function_subunit = reverse(
+            "locus_gene_function", kwargs={"name": "RAB27A"}
+        )
 
     def test_get_function(self):
         """
@@ -142,9 +148,30 @@ class GeneFunctionEndpointTests(TestCase):
             "protein_function": "Involved in early and late steps in cilia formation. Its association with CCP110 is required for inhibition of primary cilia formation by CCP110 (PubMed:18694559).",
             "uniprot_accession": "O15078",
         }
-        self.assertEqual(response.data["function"], expected_data_function)
 
+        self.assertEqual(response.data["function"], expected_data_function)
         self.assertEqual(response.data["gene_stats"], {"gain_of_function_mp": 0.637})
+        self.assertEqual(response.data["subunit_structure"], {})
+
+    def test_get_function_with_subunit(self):
+        """
+        Test the response of the gene function endpoint when there is subunit structure information available
+        """
+        response = self.client.get(self.url_gene_function_subunit)
+
+        self.assertEqual(response.status_code, 200)
+
+        expected_data_function = {
+            "protein_function": "The small GTPases Rab are key regulators of intracellular membrane trafficking, from the formation of transport vesicles to their fusion with membranes. Rabs cycle between an inactive GDP-bound form and an active GTP-bound form that is able to recruit to membranes different sets of downstream effectors directly responsible for vesicle formation, movement, tethering and fusion (PubMed:30771381). RAB27A regulates homeostasis of late endocytic pathway, including endosomal positioning, maturation and secretion (PubMed:30771381). Plays a role in cytotoxic granule exocytosis in lymphocytes. Required for both granule maturation and granule docking and priming at the immunologic synapse (PubMed:18812475)",
+            "uniprot_accession": "P51159",
+        }
+        expected_subunit_structure = {
+            "quaternary_structure": "Does not interact with the BLOC-3 complex (heterodimer of HPS1 and HPS4) (PubMed:20048159).",
+            "uniprot_accession": "P51159",
+        }
+
+        self.assertEqual(response.data["function"], expected_data_function)
+        self.assertEqual(response.data["subunit_structure"], expected_subunit_structure)
 
 
 class GeneDiseaseEndpointTests(TestCase):

--- a/gene2phenotype_project/gene2phenotype_app/views/locus.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/locus.py
@@ -248,10 +248,12 @@ class GeneFunction(BaseAPIView):
         serializer = LocusGeneSerializer
         summmary = serializer.function(queryset.first())
         gene_stats = serializer.gene_scores(queryset.first())
+        uniprot_subunit = serializer.subunit_structure(queryset.first())
         response_data = {
             "gene_symbol": queryset.first().name,
             "function": summmary,
             "gene_stats": gene_stats,
+            "subunit_structure": uniprot_subunit,
         }
 
         return Response(response_data)


### PR DESCRIPTION
### Description ###

Endpoint: `gene2phenotype/api/gene/<gene_symbol>/function/`
The endpoint now returns `subunit_structure`:
```
"subunit_structure": {
        "quaternary_structure": "Does not interact with the BLOC-3 complex (heterodimer of HPS1 and HPS4) (PubMed:20048159).",
        "uniprot_accession": "P51159"
    }
```

The data is imported by script: https://github.com/EBI-G2P/gene2phenotype_scripts/pull/69

---

### JIRA Ticket ###

[G2P-738](https://embl.atlassian.net/browse/G2P-738)

---

### Contributor Checklist ###
- [x] The code compiles and runs as expected
- [x] Relevant unit tests are added or updated
- [x] All unit tests are passing
- [x] Code follows the [G2P Coding Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51871986/G2P+Coding+Guidelines)
- [x] Documentation (code comments, confluence, etc.) has been updated as needed

---

### Reviewer Checklist ###
Please **follow the [Code Review Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51937503/Code+Review+Guidelines)** when reviewing this PR.
- [ ] I have followed all review guidelines