### PR TITLE
Fix curations endpoint to check user panels permission

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/tests/curation/test_list_curation.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/curation/test_list_curation.py
@@ -128,7 +128,7 @@ class LGDListCurationDraftsEndpoint(TestCase):
     def test_list_curation_success_with_type_automatic_and_scope_all(self):
         """
         Test successful call to list curation drafts endpoint with 'type' = 'automatic' and 'scope' = 'all'
-        Should retrieve automatic drafts of all users
+        Should retrieve automatic drafts with empty panels or panels accessible to the user
         """
         # Login
         user = User.objects.get(email="user5@test.ac.uk")
@@ -142,15 +142,17 @@ class LGDListCurationDraftsEndpoint(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
-        self.assertEqual(response.data.get("count"), 4)
+        results = response.data.get("results")
+        self.assertEqual(response.data.get("count"), 3)
         self.assertTrue(
-            all(item["type"] == "automatic" for item in response.data.get("results"))
+            all(item["type"] == "automatic" for item in results)
         )
+        self.assertNotIn("G2P00016", [item["stable_id"] for item in results])
 
     def test_list_curation_success_with_type_automatic_and_scope_unclaimed(self):
         """
         Test successful call to list curation drafts endpoint with 'type' = 'automatic' and 'scope' = 'unclaimed'
-        Should retrieve automatic drafts that are not claimed by any user
+        Should retrieve unclaimed automatic drafts with empty panels or panels accessible to the user
         """
         # Login
         user = User.objects.get(email="user5@test.ac.uk")
@@ -164,13 +166,15 @@ class LGDListCurationDraftsEndpoint(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
-        self.assertEqual(response.data.get("count"), 2)
+        results = response.data.get("results")
+        self.assertEqual(response.data.get("count"), 1)
         self.assertTrue(
-            all(item["type"] == "automatic" for item in response.data.get("results"))
+            all(item["type"] == "automatic" for item in results)
         )
         self.assertTrue(
-            all(item["curator_email"] == "g2p-admin@test.ac.uk" for item in response.data.get("results"))
+            all(item["curator_email"] == "g2p-admin@test.ac.uk" for item in results)
         )
+        self.assertNotIn("G2P00016", [item["stable_id"] for item in results])
 
     def test_list_curation_with_invalid_scope(self):
         """

--- a/gene2phenotype_project/gene2phenotype_app/views/curation.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/curation.py
@@ -8,17 +8,20 @@ from rest_framework.views import APIView
 from drf_spectacular.utils import extend_schema
 from django.db.models import Q, F
 
-from gene2phenotype_app.serializers import CurationDataSerializer
+from gene2phenotype_app.serializers import CurationDataSerializer, UserSerializer
 
 from gene2phenotype_app.models import (
     G2PStableID,
     CurationData,
     LocusGenotypeDisease,
     User,
-    UserPanel,
 )
 
 from .base import BaseView, BaseAdd, BaseUpdate, IsNotJuniorCurator
+
+
+def get_user_panel_descriptions(user):
+    return set(UserSerializer(context={"user": user}).get_panels(user.id))
 
 
 ### Curation data
@@ -96,6 +99,21 @@ class ListCurationEntries(BaseView):
     serializer_class = CurationDataSerializer
     permission_classes = [permissions.IsAuthenticated]
 
+    def curation_matches_user_panels(self, curation_data, user_panels):
+        """
+        Check if a curation draft is accessible to a user based on panels.
+        If the draft has no panels, it is accessible to all users.
+
+        Args:
+            curation_data: CurationData object
+            user_panels: list of panel descriptions the user can edit
+
+        Returns:
+            True if the draft is accessible, False otherwise.
+        """
+        panels = curation_data.json_data.get("panels", [])
+        return not panels or bool(set(panels).intersection(user_panels))
+
     def get_queryset(self):
         """
         Retrieve the queryset of CurationData objects filtered according to the provided optional query parameters.
@@ -139,6 +157,18 @@ class ListCurationEntries(BaseView):
             .order_by("-date_created")
             .distinct()
         )
+
+        # For automatic curations, only return records assigned to panels the user has access to.
+        # If the record has empty panels, it is accessible to all users.
+        if status_param == "automatic":
+            user_panels = get_user_panel_descriptions(user)
+            accessible_ids = [
+                data.pk
+                for data in queryset
+                if self.curation_matches_user_panels(data, user_panels)
+            ]
+            queryset = queryset.filter(pk__in=accessible_ids)
+
         return queryset
 
     def list(self, request, *args, **kwargs):
@@ -294,9 +324,7 @@ class ClaimCurationData(BaseUpdate):
 
         # Validate if user has permission to claim the draft
         # The draft uses the panel description as the name
-        user_panels = (UserPanel.objects.filter(user=user_obj, is_deleted=0)
-                       .annotate(panel_name=F("panel__description"))
-                       .values_list("panel_name", flat=True))
+        user_panels = get_user_panel_descriptions(user_obj)
 
         if (curation_obj.json_data["panels"] and not set(curation_obj.json_data["panels"]).intersection(set(user_panels))):
             return Response(


### PR DESCRIPTION
### Description ###

Endpoint: `gene2phenotype/api/curations/`
Update endpoint to only return curation drafts assigned to panels the user has access to. If the curation draft has no panel then it is accessible to all users.

Example: `gene2phenotype/api/curations/?scope=unclaimed&type=automatic`

---

### JIRA Ticket ###

No ticket

---

### Contributor Checklist ###
- [x] The code compiles and runs as expected
- [x] Relevant unit tests are added or updated
- [x] All unit tests are passing
- [x] Code follows the [G2P Coding Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51871986/G2P+Coding+Guidelines)
- [x] Documentation (code comments, confluence, etc.) has been updated as needed

---

### Reviewer Checklist ###
Please **follow the [Code Review Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51937503/Code+Review+Guidelines)** when reviewing this PR.
- [ ] I have followed all review guidelines