### PR TITLE
Allow to access draft curation assigned to other users

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/tests/curation/test_get_curation.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/curation/test_get_curation.py
@@ -26,6 +26,9 @@ class LGDGetCurationDraftEndpoint(TestCase):
         self.url_get_no_curation = reverse(
             "curation_details", kwargs={"stable_id": "G2P00001"}
         )
+        self.url_get_panel_restricted_curation = reverse(
+            "curation_details", kwargs={"stable_id": "G2P00016"}
+        )
 
     def test_get_curation_success(self):
         """
@@ -45,6 +48,45 @@ class LGDGetCurationDraftEndpoint(TestCase):
         self.assertEqual(response.data.get("session_name"), "test session")
         self.assertEqual(response.data.get("type"), "manual")
         self.assertEqual(response.data.get("curator_email"), "user5@test.ac.uk")
+
+    def test_get_curation_success_when_user_panel_matches(self):
+        """
+        Test successful call to get a curation draft owned by another user
+        when the logged-in user has access to one of the draft's panels.
+        """
+        # Login
+        user = User.objects.get(email="john@test.ac.uk")
+        refresh = RefreshToken.for_user(user)
+        access_token = str(refresh.access_token)
+
+        # Authenticate by setting cookie on the test client
+        self.client.cookies[settings.SIMPLE_JWT["AUTH_COOKIE"]] = access_token
+
+        response = self.client.get(self.url_get_panel_restricted_curation)
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(response.data.get("stable_id"), "G2P00016")
+        self.assertEqual(response.data.get("type"), "automatic")
+        self.assertEqual(response.data.get("curator_email"), "g2p-admin@test.ac.uk")
+
+    def test_get_curation_not_found_when_user_panel_does_not_match(self):
+        """
+        Test call to get a curation draft owned by another user
+        when the logged-in user does not have access to any of the draft's panels.
+        """
+        # Login
+        user = User.objects.get(email="user5@test.ac.uk")
+        refresh = RefreshToken.for_user(user)
+        access_token = str(refresh.access_token)
+
+        # Authenticate by setting cookie on the test client
+        self.client.cookies[settings.SIMPLE_JWT["AUTH_COOKIE"]] = access_token
+
+        response = self.client.get(self.url_get_panel_restricted_curation)
+        self.assertEqual(response.status_code, 404)
+
+        response = response.json()
+        self.assertEqual(response["error"], "No matching Entry found for: G2P00016")
 
     def test_get_curation_unauthorised_access(self):
         """

--- a/gene2phenotype_project/gene2phenotype_app/views/curation.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/curation.py
@@ -222,14 +222,24 @@ class CurationDataDetail(BaseView):
         user = self.request.user
 
         g2p_stable_id = get_object_or_404(G2PStableID, stable_id=stable_id)
-        # Get the entry if the user matches
+
         queryset = CurationData.objects.filter(
-            stable_id=g2p_stable_id, user__email=user
+            stable_id=g2p_stable_id
         ).annotate(
             first_name=F("user_id__first_name"),
             last_name=F("user_id__last_name"),
             user_email=F("user__email"),
         )
+
+        # Keep entries owned by the user or entries with at least one panel the user can edit
+        user_panels = set(get_user_panel_descriptions(user))
+        accessible_ids = [
+            data.pk
+            for data in queryset
+            if data.user_id == user.id
+            or set(data.json_data.get("panels", [])).intersection(user_panels)
+        ]
+        queryset = queryset.filter(pk__in=accessible_ids)
 
         if not queryset.exists():
             self.handle_no_permission("Entry", stable_id)


### PR DESCRIPTION
### Description ###

**Updates**
- [x] `curation/<str:stable_id>/`
    - [x] return curation entries owned by the user or entries with at least one panel the user can edit
- [x] `curation/<str:stable_id>/update/`
    - [x] return the curation entry if it is owned by the user or it is assigned to at least one panel the user can edit
    - [x] sets the `status` to `manual` (already implemented)
- [ ] `curation/publish/<str:stable_id>/`
    - [x] return the curation entry if it is owned by the user or it is associated with a junior curator and assigned to at least one panel the user can edit
    - [ ] if the user assigned to the entry if a junior curator then add private comment "Approved by _curator_"

---

### JIRA Ticket ###

Related to [G2P-745](https://embl.atlassian.net/browse/G2P-745)

---

### Contributor Checklist ###
- [ ] The code compiles and runs as expected
- [ ] Relevant unit tests are added or updated
- [ ] All unit tests are passing
- [ ] Code follows the [G2P Coding Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51871986/G2P+Coding+Guidelines)
- [ ] Documentation (code comments, confluence, etc.) has been updated as needed

---

### Reviewer Checklist ###
Please **follow the [Code Review Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51937503/Code+Review+Guidelines)** when reviewing this PR.
- [ ] I have followed all review guidelines