### PR TITLE
Fix the response of endpoint to verify email

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/serializers/user.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/user.py
@@ -521,7 +521,6 @@ class VerifyEmailSerializer(serializers.ModelSerializer):
         email = self.validated_data.get("email")
         user = User.objects.filter(email=email, is_deleted=0).first()
 
-        # Verify Email and return token and id that will be used to reset the password
         if user:
             reset_token = PasswordResetTokenGenerator().make_token(user)
             uid = urlsafe_base64_encode(force_bytes(user.id))
@@ -535,12 +534,10 @@ class VerifyEmailSerializer(serializers.ModelSerializer):
                 reset_link=reset_link,
                 to_email=user.email,
             )
-            return {"id": user.id, "email": user.email, "token": reset_token}
-        else:
-            # If user not found, return a generic response to avoid user enumeration
-            return {
-                "message": "If an account exists for this email, a reset link has been sent."
-            }
+
+        return {
+            "message": "If an account exists for this email, a reset link has been sent."
+        }
 
     class Meta:
         model = User

--- a/gene2phenotype_project/gene2phenotype_app/tests/views/test_user.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/views/test_user.py
@@ -261,9 +261,7 @@ class ChangePasswordTest(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn("id", response.data)
-        self.assertIn("email", response.data)
-        self.assertIn("token", response.data)
+        self.assertEqual(response.data["message"], "If an account exists for this email, a reset link has been sent.")
 
     def test_verify_email_failure(self):
         """


### PR DESCRIPTION
### Description ###

Endpoint: `verify/email/`
This endpoint returns the token and user id which is risky.

The reset password has been tested locally.

---

### JIRA Ticket ###

No ticket

---

### Contributor Checklist ###
- [x] The code compiles and runs as expected
- [x] Relevant unit tests are added or updated
- [x] All unit tests are passing
- [x] Code follows the [G2P Coding Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51871986/G2P+Coding+Guidelines)
- [x] Documentation (code comments, confluence, etc.) has been updated as needed

---

### Reviewer Checklist ###
Please **follow the [Code Review Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51937503/Code+Review+Guidelines)** when reviewing this PR.
- [ ] I have followed all review guidelines