### PR TITLE
Update access to curation drafts

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/serializers/curation.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/curation.py
@@ -468,7 +468,6 @@ class CurationDataSerializer(serializers.ModelSerializer):
         # Get user object
         try:
             user_obj = User.objects.get(email=user, is_active=1)
-
         except User.DoesNotExist:
             raise serializers.ValidationError({"error": f"Invalid user '{user}'"})
 

--- a/gene2phenotype_project/gene2phenotype_app/tests/curation/test_get_curation.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/curation/test_get_curation.py
@@ -26,6 +26,9 @@ class LGDGetCurationDraftEndpoint(TestCase):
         self.url_get_no_curation = reverse(
             "curation_details", kwargs={"stable_id": "G2P00001"}
         )
+        self.url_get_panel_restricted_curation = reverse(
+            "curation_details", kwargs={"stable_id": "G2P00016"}
+        )
 
     def test_get_curation_success(self):
         """
@@ -45,6 +48,45 @@ class LGDGetCurationDraftEndpoint(TestCase):
         self.assertEqual(response.data.get("session_name"), "test session")
         self.assertEqual(response.data.get("type"), "manual")
         self.assertEqual(response.data.get("curator_email"), "user5@test.ac.uk")
+
+    def test_get_curation_success_when_user_panel_matches(self):
+        """
+        Test successful call to get a curation draft owned by another user
+        when the logged-in user has access to one of the draft's panels.
+        """
+        # Login
+        user = User.objects.get(email="john@test.ac.uk")
+        refresh = RefreshToken.for_user(user)
+        access_token = str(refresh.access_token)
+
+        # Authenticate by setting cookie on the test client
+        self.client.cookies[settings.SIMPLE_JWT["AUTH_COOKIE"]] = access_token
+
+        response = self.client.get(self.url_get_panel_restricted_curation)
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(response.data.get("stable_id"), "G2P00016")
+        self.assertEqual(response.data.get("type"), "automatic")
+        self.assertEqual(response.data.get("curator_email"), "g2p-admin@test.ac.uk")
+
+    def test_get_curation_not_found_when_user_panel_does_not_match(self):
+        """
+        Test call to get a curation draft owned by another user
+        when the logged-in user does not have access to any of the draft's panels.
+        """
+        # Login
+        user = User.objects.get(email="user5@test.ac.uk")
+        refresh = RefreshToken.for_user(user)
+        access_token = str(refresh.access_token)
+
+        # Authenticate by setting cookie on the test client
+        self.client.cookies[settings.SIMPLE_JWT["AUTH_COOKIE"]] = access_token
+
+        response = self.client.get(self.url_get_panel_restricted_curation)
+        self.assertEqual(response.status_code, 404)
+
+        response = response.json()
+        self.assertEqual(response["error"], "No matching Entry found for: G2P00016")
 
     def test_get_curation_unauthorised_access(self):
         """

--- a/gene2phenotype_project/gene2phenotype_app/tests/curation/test_publish.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/curation/test_publish.py
@@ -40,12 +40,103 @@ class LGDAddCurationEndpoint(TestCase):
             refresh.access_token
         )
 
+    def login_as(self, email):
+        self.user = User.objects.get(email=email)
+        refresh = RefreshToken.for_user(self.user)
+        self.client.cookies[settings.SIMPLE_JWT["AUTH_COOKIE"]] = str(
+            refresh.access_token
+        )
+
     def login_junior_user(self):
         self.user = User.objects.get(email="elisa@test.ac.uk")
         refresh = RefreshToken.for_user(self.user)
         self.client.cookies[settings.SIMPLE_JWT["AUTH_COOKIE"]] = str(
             refresh.access_token
         )
+
+    def get_publishable_curation_payload(
+        self,
+        session_name="Test B",
+        panels=None,
+        disease_name="SRY-related 46,xx sex reversal",
+    ):
+        return {
+            "json_data": {
+                "allelic_requirement": "monoallelic_Y_hemizygous",
+                "confidence": "limited",
+                "cross_cutting_modifier": ["potential secondary finding"],
+                "disease": {
+                    "cross_references": [
+                        {
+                            "disease_name": "46,xx sex reversal",
+                            "identifier": "MONDO:0100250",
+                            "original_disease_name": "46,xx sex reversal",
+                            "source": "Mondo",
+                        }
+                    ],
+                    "disease_name": disease_name,
+                },
+                "locus": "SRY",
+                "mechanism_evidence": [
+                    {
+                        "description": "test comment",
+                        "evidence_types": [
+                            {
+                                "primary_type": "Rescue",
+                                "secondary_type": ["Patient Cells"],
+                            }
+                        ],
+                        "pmid": "1",
+                    }
+                ],
+                "mechanism_synopsis": [
+                    {"name": "destabilising LOF", "support": "inferred"}
+                ],
+                "molecular_mechanism": {
+                    "name": "loss of function",
+                    "support": "evidence",
+                },
+                "panels": panels or ["Developmental disorders"],
+                "phenotypes": [],
+                "private_comment": "test comment",
+                "public_comment": "test comment public",
+                "publications": [
+                    {
+                        "affectedIndividuals": 1,
+                        "ancestries": "test",
+                        "authors": "Makar AB, McMartin KE, Palese M, Tephly TR.",
+                        "comment": "test comment",
+                        "consanguineous": "no",
+                        "families": 1,
+                        "pmid": "1",
+                        "source": "G2P",
+                        "title": "Formate assay in body fluids: application in methanol poisoning.",
+                        "year": 1975,
+                    }
+                ],
+                "session_name": session_name,
+                "variant_consequences": [
+                    {
+                        "support": "inferred",
+                        "variant_consequence": "decreased_gene_product_level",
+                    }
+                ],
+                "variant_descriptions": [
+                    {"description": "test description", "publication": "1"}
+                ],
+                "variant_types": [
+                    {
+                        "comment": "test comment",
+                        "de_novo": True,
+                        "inherited": True,
+                        "primary_type": "protein_changing",
+                        "secondary_type": "missense_variant",
+                        "supporting_papers": ["1"],
+                        "unknown_inheritance": False,
+                    }
+                ],
+            }
+        }
 
     def test_publish_incorrect_genotype(self):
         """
@@ -448,84 +539,7 @@ class LGDAddCurationEndpoint(TestCase):
         Test successful call to publish a record
         """
         self.login_user()
-        # Define the input data structure
-        data_to_add = {
-            "json_data": {
-                "allelic_requirement": "monoallelic_Y_hemizygous",
-                "confidence": "limited",
-                "cross_cutting_modifier": ["potential secondary finding"],
-                "disease": {
-                    "cross_references": [
-                        {
-                            "disease_name": "46,xx sex reversal",
-                            "identifier": "MONDO:0100250",
-                            "original_disease_name": "46,xx sex reversal",
-                            "source": "Mondo",
-                        }
-                    ],
-                    "disease_name": "SRY-related 46,xx sex reversal",
-                },
-                "locus": "SRY",
-                "mechanism_evidence": [
-                    {
-                        "description": "test comment",
-                        "evidence_types": [
-                            {
-                                "primary_type": "Rescue",
-                                "secondary_type": ["Patient Cells"],
-                            }
-                        ],
-                        "pmid": "1",
-                    }
-                ],
-                "mechanism_synopsis": [
-                    {"name": "destabilising LOF", "support": "inferred"}
-                ],
-                "molecular_mechanism": {
-                    "name": "loss of function",
-                    "support": "evidence",
-                },
-                "panels": ["Developmental disorders"],
-                "phenotypes": [],
-                "private_comment": "test comment",
-                "public_comment": "test comment public",
-                "publications": [
-                    {
-                        "affectedIndividuals": 1,
-                        "ancestries": "test",
-                        "authors": "Makar AB, McMartin KE, Palese M, Tephly TR.",
-                        "comment": "test comment",
-                        "consanguineous": "no",
-                        "families": 1,
-                        "pmid": "1",
-                        "source": "G2P",
-                        "title": "Formate assay in body fluids: application in methanol poisoning.",
-                        "year": 1975,
-                    }
-                ],
-                "session_name": "Test B",
-                "variant_consequences": [
-                    {
-                        "support": "inferred",
-                        "variant_consequence": "decreased_gene_product_level",
-                    }
-                ],
-                "variant_descriptions": [
-                    {"description": "test description", "publication": "1"}
-                ],
-                "variant_types": [
-                    {
-                        "comment": "test comment",
-                        "de_novo": True,
-                        "inherited": True,
-                        "primary_type": "protein_changing",
-                        "secondary_type": "missense_variant",
-                        "supporting_papers": ["1"],
-                        "unknown_inheritance": False,
-                    }
-                ],
-            }
-        }
+        data_to_add = self.get_publishable_curation_payload()
 
         # Save the curation draft
         response = self.client.post(
@@ -571,6 +585,134 @@ class LGDAddCurationEndpoint(TestCase):
             lgd_publication=lgd_publications[0], is_deleted=0
         )
         self.assertEqual(len(lgd_publication_comments), 1)
+
+    def test_publish_unauthorised_access(self):
+        """
+        Test publishing a record without authentication
+        """
+        url_publish = reverse("publish_record", kwargs={"stable_id": "G2P00010"})
+
+        response_publish = self.client.post(
+            url_publish, content_type="application/json"
+        )
+        self.assertEqual(response_publish.status_code, 401)
+
+    def test_publish_success_when_user_owns_entry_without_panel_access(self):
+        """
+        Test publishing succeeds for the owner even when the draft panel
+        is not in the user's panel assignments.
+        """
+        self.login_user()
+
+        data_to_add = self.get_publishable_curation_payload(
+            session_name="Test owner no panel",
+            disease_name="SRY-related 46,xx sex reversal owner no panel",
+        )
+
+        response = self.client.post(
+            self.url_add_curation, data_to_add, content_type="application/json"
+        )
+        self.assertEqual(response.status_code, 200)
+
+        stable_id = response.json()["result"]
+        from gene2phenotype_app.models import CurationData
+
+        curation_obj = CurationData.objects.get(stable_id__stable_id=stable_id)
+        curation_obj.json_data["panels"] = ["Cancer disorders"]
+        curation_obj.save(update_fields=["json_data"])
+
+        url_publish = reverse("publish_record", kwargs={"stable_id": stable_id})
+
+        response_publish = self.client.post(
+            url_publish, content_type="application/json"
+        )
+        self.assertEqual(response_publish.status_code, 201)
+
+    def test_publish_success_when_junior_owned_entry_panel_matches(self):
+        """
+        Test publishing succeeds for a non-junior user when the draft is owned
+        by a junior curator and the user has access to the draft panel.
+        """
+        self.login_junior_user()
+
+        data_to_add = self.get_publishable_curation_payload(
+            session_name="Test junior match",
+            panels=["Developmental disorders"],
+            disease_name="SRY-related 46,xx sex reversal junior match",
+        )
+
+        response = self.client.post(
+            self.url_add_curation, data_to_add, content_type="application/json"
+        )
+        self.assertEqual(response.status_code, 200)
+
+        stable_id = response.json()["result"]
+
+        self.login_user()
+        url_publish = reverse("publish_record", kwargs={"stable_id": stable_id})
+
+        response_publish = self.client.post(
+            url_publish, content_type="application/json"
+        )
+        self.assertEqual(response_publish.status_code, 201)
+
+    def test_publish_not_found_when_junior_owned_entry_panel_does_not_match(self):
+        """
+        Test publishing is rejected when the draft is owned by a junior curator
+        but the user has no access to the draft panel.
+        """
+        self.login_junior_user()
+
+        data_to_add = self.get_publishable_curation_payload(
+            session_name="Test junior no match",
+            disease_name="SRY-related 46,xx sex reversal junior no match",
+        )
+
+        response = self.client.post(
+            self.url_add_curation, data_to_add, content_type="application/json"
+        )
+        self.assertEqual(response.status_code, 200)
+
+        stable_id = response.json()["result"]
+        from gene2phenotype_app.models import CurationData
+
+        curation_obj = CurationData.objects.get(stable_id__stable_id=stable_id)
+        curation_obj.json_data["panels"] = ["Cancer disorders"]
+        curation_obj.save(update_fields=["json_data"])
+
+        self.login_user()
+        url_publish = reverse("publish_record", kwargs={"stable_id": stable_id})
+
+        response_publish = self.client.post(
+            url_publish, content_type="application/json"
+        )
+        self.assertEqual(response_publish.status_code, 404)
+
+        response_data_publish = response_publish.json()
+        self.assertEqual(
+            response_data_publish["error"],
+            f"Could not find 'Entry' for ID '{stable_id}'",
+        )
+
+    def test_publish_not_found_when_other_user_owns_non_junior_entry(self):
+        """
+        Test publishing is rejected when the draft is owned by another user
+        who is not a junior curator.
+        """
+        self.login_as("john@test.ac.uk")
+
+        url_publish = reverse("publish_record", kwargs={"stable_id": "G2P00004"})
+
+        response_publish = self.client.post(
+            url_publish, content_type="application/json"
+        )
+        self.assertEqual(response_publish.status_code, 404)
+
+        response_data_publish = response_publish.json()
+        self.assertEqual(
+            response_data_publish["error"],
+            "Could not find 'Entry' for ID 'G2P00004'",
+        )
 
     def test_publish_similar_record(self):
         """

--- a/gene2phenotype_project/gene2phenotype_app/tests/curation/test_update_curation.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/curation/test_update_curation.py
@@ -28,6 +28,9 @@ class LGDUpdateCurationEndpoint(TestCase):
         self.url_update_curation_2 = reverse(
             "update_curation", kwargs={"stable_id": "G2P00010"}
         )
+        self.url_update_curation_panel_restricted = reverse(
+            "update_curation", kwargs={"stable_id": "G2P00016"}
+        )
         self.url_update_invalid_curation = reverse(
             "update_curation", kwargs={"stable_id": "G2P00123"}
         )
@@ -39,14 +42,15 @@ class LGDUpdateCurationEndpoint(TestCase):
             refresh.access_token
         )
 
-    def test_update_curation_success(self):
-        """
-        Test successful call to update curation endpoint
-        """
-        self.login_user()
+    def login_as(self, email):
+        user = User.objects.get(email=email)
+        refresh = RefreshToken.for_user(user)
+        self.client.cookies[settings.SIMPLE_JWT["AUTH_COOKIE"]] = str(
+            refresh.access_token
+        )
 
-        # Define the complex data structure
-        curation_to_update = {
+    def get_valid_curation_payload(self):
+        return {
             "json_data": {
                 "allelic_requirement": "biallelic_autosomal",
                 "confidence": "limited",
@@ -134,6 +138,14 @@ class LGDUpdateCurationEndpoint(TestCase):
                 ],
             }
         }
+
+    def test_update_curation_success(self):
+        """
+        Test successful call to update curation endpoint
+        """
+        self.login_user()
+
+        curation_to_update = self.get_valid_curation_payload()
 
         response = self.client.put(
             self.url_update_curation,
@@ -177,99 +189,95 @@ class LGDUpdateCurationEndpoint(TestCase):
         self.assertEqual(curation_obj.json_data, original_json)
         self.assertEqual(curation_obj.status, "manual")
 
+    def test_update_curation_unauthorised_access(self):
+        """
+        Test call to update curation endpoint without authentication
+        """
+        response = self.client.put(
+            self.url_update_curation,
+            self.get_valid_curation_payload(),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_update_curation_success_when_user_owns_entry_and_panel_matches(self):
+        """
+        Test successful update when the curation belongs to the user and
+        the curation panels match the user's panel access.
+        """
+        self.login_user()
+
+        curation_obj = CurationData.objects.get(stable_id__stable_id="G2P00004")
+        curation_obj.json_data["panels"] = ["Developmental disorders"]
+        curation_obj.save(update_fields=["json_data"])
+
+        response = self.client.put(
+            self.url_update_curation,
+            self.get_valid_curation_payload(),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_update_curation_success_when_user_panel_matches_but_entry_is_owned_by_another_user(self):
+        """
+        Test update succeeds when the user does not own the curation but
+        has access to one of the curation panels.
+        """
+        self.login_as("john@test.ac.uk")
+
+        curation_to_update = self.get_valid_curation_payload()
+        curation_to_update["json_data"]["panels"] = ["Cardiac disorders"]
+        curation_to_update["json_data"]["locus"] = "TUBB4A"
+
+        response = self.client.put(
+            self.url_update_curation_panel_restricted,
+            curation_to_update,
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+
+        response_data = response.json()
+        self.assertEqual(
+            response_data["message"],
+            "Data updated successfully for session name 'test automic curation TUBB4A'",
+        )
+
+        curation_obj = CurationData.objects.get(stable_id__stable_id="G2P00016")
+        self.assertEqual(curation_obj.json_data["locus"], "TUBB4A")
+        self.assertEqual(curation_obj.json_data["panels"], ["Cardiac disorders"])
+
+    def test_update_curation_success_when_user_owns_entry_but_panel_does_not_match(self):
+        """
+        Test update succeeds when the user owns the curation even if the
+        curation panels do not match the user's panel assignments.
+        """
+        self.login_user()
+
+        curation_obj = CurationData.objects.get(stable_id__stable_id="G2P00004")
+        curation_obj.json_data["panels"] = ["Cardiac disorders"]
+        curation_obj.save(update_fields=["json_data"])
+
+        curation_to_update = self.get_valid_curation_payload()
+        curation_to_update["json_data"]["panels"] = ["Cardiac disorders"]
+
+        response = self.client.put(
+            self.url_update_curation,
+            curation_to_update,
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+
+        response_data = response.json()
+        self.assertEqual(
+            response_data["message"],
+            "Data updated successfully for session name 'test session'",
+        )
+
     def test_update_curation_no_permission(self):
         """
         Test call to update curation endpoint with super user who does not have permission to update the curation
         """
-        # Define the complex data structure
-        curation_to_update = {
-            "json_data": {
-                "allelic_requirement": "biallelic_autosomal",
-                "confidence": "limited",
-                "cross_cutting_modifier": ["potential secondary finding"],
-                "disease": {
-                    "cross_references": [
-                        {
-                            "disease_name": "bardet-biedl syndrome",
-                            "identifier": "615991",
-                            "original_disease_name": "BARDET-BIEDL SYNDROME 14",
-                            "source": "OMIM",
-                        }
-                    ],
-                    "disease_name": "CEP290-related bardet-biedl syndrome",
-                },
-                "locus": "CEP290",
-                "mechanism_evidence": [
-                    {
-                        "description": "updated test comment",
-                        "evidence_types": [
-                            {
-                                "primary_type": "Rescue",
-                                "secondary_type": ["Patient Cells"],
-                            }
-                        ],
-                        "pmid": "1",
-                    }
-                ],
-                "mechanism_synopsis": [
-                    {"name": "destabilising LOF", "support": "inferred"}
-                ],
-                "molecular_mechanism": {
-                    "name": "loss of function",
-                    "support": "evidence",
-                },
-                "panels": ["Developmental disorders"],
-                "phenotypes": [
-                    {
-                        "hpo_terms": [
-                            {
-                                "accession": "HP:0012372",
-                                "term": "Abnormal eye morphology",
-                            }
-                        ],
-                        "pmid": "1",
-                        "summary": "updated test comment",
-                    }
-                ],
-                "private_comment": "updated test comment",
-                "public_comment": "updated test comment",
-                "publications": [
-                    {
-                        "affectedIndividuals": 1,
-                        "ancestries": "updated test",
-                        "authors": "Makar AB, McMartin KE, Palese M, Tephly TR.",
-                        "comment": "updated test comment",
-                        "consanguineous": "no",
-                        "families": 1,
-                        "pmid": "1",
-                        "source": "G2P",
-                        "title": "Formate assay in body fluids: application in methanol poisoning.",
-                        "year": 1975,
-                    }
-                ],
-                "session_name": "test session",
-                "variant_consequences": [
-                    {
-                        "support": "inferred",
-                        "variant_consequence": "altered_gene_product_level",
-                    }
-                ],
-                "variant_descriptions": [
-                    {"description": "updated test description", "publication": "1"}
-                ],
-                "variant_types": [
-                    {
-                        "comment": "updated test comment",
-                        "de_novo": True,
-                        "inherited": True,
-                        "primary_type": "protein_changing",
-                        "secondary_type": "missense_variant",
-                        "supporting_papers": ["1"],
-                        "unknown_inheritance": False,
-                    }
-                ],
-            }
-        }
+        curation_to_update = self.get_valid_curation_payload()
 
         # Login
         user = User.objects.get(email="john@test.ac.uk")

--- a/gene2phenotype_project/gene2phenotype_app/views/curation.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/curation.py
@@ -270,6 +270,9 @@ class CurationDataDetail(BaseView):
         """
         curation_data_obj = self.get_queryset().first()
 
+        curation_user_obj = User.objects.get(email=curation_data_obj.user)
+        unclaimed_draft = curation_user_obj.groups.filter(name__in=["g2p_admin"]).exists()
+
         response_data = {
             "session_name": curation_data_obj.session_name,
             "stable_id": curation_data_obj.stable_id.stable_id,
@@ -281,6 +284,10 @@ class CurationDataDetail(BaseView):
             "curator_last_name": curation_data_obj.last_name,
             "curator_email": curation_data_obj.user_email,
         }
+
+        if unclaimed_draft:
+            response_data["unclaimed_draft"] = True
+
         return Response(response_data)
 
 

--- a/gene2phenotype_project/gene2phenotype_app/views/curation.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/curation.py
@@ -225,14 +225,24 @@ class CurationDataDetail(BaseView):
         user = self.request.user
 
         g2p_stable_id = get_object_or_404(G2PStableID, stable_id=stable_id)
-        # Get the entry if the user matches
+
         queryset = CurationData.objects.filter(
-            stable_id=g2p_stable_id, user__email=user
+            stable_id=g2p_stable_id
         ).annotate(
             first_name=F("user_id__first_name"),
             last_name=F("user_id__last_name"),
             user_email=F("user__email"),
         )
+
+        # Keep entries owned by the user or entries with at least one panel the user can edit
+        user_panels = set(get_user_panel_descriptions(user))
+        accessible_ids = [
+            data.pk
+            for data in queryset
+            if data.user_id == user.id
+            or set(data.json_data.get("panels", [])).intersection(user_panels)
+        ]
+        queryset = queryset.filter(pk__in=accessible_ids)
 
         if not queryset.exists():
             self.handle_no_permission("Entry", stable_id)

--- a/gene2phenotype_project/gene2phenotype_app/views/curation.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/curation.py
@@ -291,6 +291,14 @@ class ClaimCurationData(BaseUpdate):
     permission_classes = [permissions.IsAuthenticated]
 
     def get_queryset(self):
+        """
+        Retrieve the queryset of CurationData objects filtered by stable_id.
+
+        Args:
+            stable_id (string): The stable ID to filter the CurationData objects.
+        Returns:
+            Queryset of CurationData objects filtered by stable_id.
+        """
         stable_id = self.kwargs["stable_id"]
 
         g2p_stable_id = get_object_or_404(G2PStableID, stable_id=stable_id)
@@ -366,6 +374,11 @@ class UpdateCurationData(BaseUpdate):
     permission_classes = [permissions.IsAuthenticated]
 
     def get_queryset(self):
+        """
+        Retrieve the queryset of CurationData objects filtered by:
+         - stable_id
+         - user permissions: only entries owned by the user or entries with at least one panel the user can edit
+        """
         stable_id = self.kwargs["stable_id"]
         user = self.request.user
 
@@ -454,10 +467,42 @@ class UpdateCurationData(BaseUpdate):
 
 
 @extend_schema(exclude=True)
-class PublishRecord(APIView):
+class PublishRecord(BaseUpdate):
     http_method_names = ["post", "head"]
     serializer_class = CurationDataSerializer
     permission_classes = [permissions.IsAuthenticated, IsNotJuniorCurator]
+
+    def get_queryset(self):
+        """
+        Retrieve the queryset of CurationData objects filtered by:
+         - stable_id
+         - user permissions: own entries or entries associated with junior curators in panels the user can edit
+        """
+        stable_id = self.kwargs["stable_id"]
+        user = self.request.user
+
+        g2p_stable_id = get_object_or_404(G2PStableID, stable_id=stable_id)
+
+        filters = Q(stable_id=g2p_stable_id) & (Q(user__email=user) | Q(user__groups__name="junior_curator"))
+
+        queryset = CurationData.objects.filter(
+            filters
+        )
+
+        # Keep entries owned by the user or entries with at least one panel the user can edit
+        user_panels = set(get_user_panel_descriptions(user))
+        accessible_ids = [
+            data.pk
+            for data in queryset
+            if data.user_id == user.id
+            or set(data.json_data.get("panels", [])).intersection(user_panels)
+        ]
+        queryset = queryset.filter(pk__in=accessible_ids)
+
+        if not queryset.exists():
+            self.handle_no_permission("Entry", stable_id)
+        else:
+            return queryset
 
     def post(self, request, stable_id):
         """
@@ -475,9 +520,7 @@ class PublishRecord(APIView):
 
         try:
             # Get curation record
-            curation_obj = CurationData.objects.get(
-                stable_id__stable_id=stable_id, user__email=user
-            )
+            curation_obj = self.get_queryset().first()
 
             # Cannot publish if status is 'automatic'
             if curation_obj.status == "automatic":

--- a/gene2phenotype_project/gene2phenotype_app/views/curation.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/curation.py
@@ -370,10 +370,20 @@ class UpdateCurationData(BaseUpdate):
         user = self.request.user
 
         g2p_stable_id = get_object_or_404(G2PStableID, stable_id=stable_id)
-        # Get the entry for this user
+
         queryset = CurationData.objects.filter(
-            stable_id=g2p_stable_id, user__email=user
+            stable_id=g2p_stable_id
         )
+
+        # Keep entries owned by the user or entries with at least one panel the user can edit
+        user_panels = set(get_user_panel_descriptions(user))
+        accessible_ids = [
+            data.pk
+            for data in queryset
+            if data.user_id == user.id
+            or set(data.json_data.get("panels", [])).intersection(user_panels)
+        ]
+        queryset = queryset.filter(pk__in=accessible_ids)
 
         if not queryset.exists():
             self.handle_no_permission("Entry", stable_id)
@@ -384,6 +394,7 @@ class UpdateCurationData(BaseUpdate):
         """
         Update the JSON data for the specific G2P ID.
         It replaces the existing json with the new data.
+        If the curation draft is 'automatic', it changes the status to 'manual' when updated.
 
         Args:
             stable_id (string)
@@ -458,7 +469,7 @@ class PublishRecord(APIView):
             stable_id (string)
 
         Returns:
-                Response message
+            Response message
         """
         user = request.user
 


### PR DESCRIPTION
### Description ###

**Updates**
- [x] `curation/<str:stable_id>/`
    - [x] return curation entries owned by the user or entries with at least one panel the user can edit
- [x] `curation/<str:stable_id>/update/`
    - [x] return the curation entry if it is owned by the user or it is assigned to at least one panel the user can edit
    - [x] sets the `status` to `manual` (already implemented)
- [x] `curation/publish/<str:stable_id>/`
    - [x] return the curation entry if it is owned by the user or it is associated with a junior curator and assigned to at least one panel the user can edit
    - [ ] if the user assigned to the entry if a junior curator then add private comment "Approved by _curator_" TODO in separate PR

---

### JIRA Ticket ###

Related to [G2P-745](https://embl.atlassian.net/browse/G2P-745)

---

### Contributor Checklist ###
- [ ] The code compiles and runs as expected
- [ ] Relevant unit tests are added or updated
- [ ] All unit tests are passing
- [ ] Code follows the [G2P Coding Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51871986/G2P+Coding+Guidelines)
- [ ] Documentation (code comments, confluence, etc.) has been updated as needed

---

### Reviewer Checklist ###
Please **follow the [Code Review Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51937503/Code+Review+Guidelines)** when reviewing this PR.
- [ ] I have followed all review guidelines