### PR TITLE
Fix host header poisoning in emailed reset and verification links

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,7 @@ jobs:
           echo "AUTH_COOKIE_SECURE=False" >> /home/runner/work/config.ini
           echo "STATIC_ROOT=" >> /home/runner/work/config.ini
           echo "STATIC_URL=static/" >> /home/runner/work/config.ini
+          echo "PUBLIC_APP_URL=http://localhost:5173" >> /home/runner/work/config.ini
           echo "[g2p]" >> /home/runner/work/config.ini
           echo "version=3.0.0" >> /home/runner/work/config.ini
 

--- a/gene2phenotype_project/gene2phenotype_app/serializers/user.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/user.py
@@ -10,7 +10,7 @@ from django.contrib.auth.models import update_last_login
 from django.core.exceptions import ObjectDoesNotExist
 
 
-from ..utils import CustomMail
+from ..utils import CustomMail, build_public_url
 from ..models import User, UserPanel, Panel
 
 
@@ -247,11 +247,7 @@ class CreateUserSerializer(serializers.ModelSerializer):
                 panel = Panel.objects.get(name=panel)
                 UserPanel.objects.create(user=user, panel=panel, is_deleted=False)
 
-            request = self.context.get("request")
-            # base_url = url_link.build_absolute_uri()
-            http_response = request.scheme
-            host = request.get_host()
-            verify_email_link = f"{http_response}://{host}/verify/email"
+            verify_email_link = build_public_url("/verify/email")
             CustomMail.send_create_email(
                 data=user,
                 verify_link=verify_email_link,
@@ -535,10 +531,9 @@ class VerifyEmailSerializer(serializers.ModelSerializer):
         if user:
             reset_token = PasswordResetTokenGenerator().make_token(user)
             uid = urlsafe_base64_encode(force_bytes(user.id))
-            request = self.context.get("request")
-            http_response = request.scheme
-            host = request.get_host()
-            reset_link = f"{http_response}://{host}/gene2phenotype/reset-password/{uid}/{reset_token}"
+            reset_link = build_public_url(
+                f"/gene2phenotype/reset-password/{uid}/{reset_token}"
+            )
             CustomMail.send_reset_email(
                 user=user.first_name,
                 subject="Reset password request",

--- a/gene2phenotype_project/gene2phenotype_app/tests/views/test_user.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/views/test_user.py
@@ -3,11 +3,13 @@ from django.conf import settings
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
+from django.test.utils import override_settings
 from django.contrib.auth.tokens import PasswordResetTokenGenerator
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
 from gene2phenotype_app.models import User
 from rest_framework_simplejwt.tokens import RefreshToken
+from unittest.mock import patch
 
 
 def login(user):
@@ -113,6 +115,37 @@ class CreateUserEndpointTest(TestCase):
             self.url_create_user, json_data, content_type="application/json"
         )
         self.assertEqual(response.status_code, 400)
+
+    @override_settings(
+        PUBLIC_APP_URL="https://public.example.org",
+        ALLOWED_HOSTS=["testserver", "evil.example"],
+    )
+    @patch("gene2phenotype_app.serializers.user.CustomMail.send_create_email")
+    def test_create_user_email_uses_public_app_url(self, mock_send_create_email):
+        post_data = {
+            "username": "test_user31",
+            "email": "user31@test.ac.uk",
+            "first_name": "First name test",
+            "last_name": "Last name test",
+            "password": "testpassword31",
+            "password2": "testpassword31",
+            "is_superuser": False,
+            "is_staff": False,
+            "panels": ["DD"],
+        }
+
+        response = self.client.post(
+            self.url_create_user,
+            json.dumps(post_data),
+            content_type="application/json",
+            HTTP_HOST="evil.example",
+        )
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(mock_send_create_email.call_count, 1)
+        self.assertEqual(
+            mock_send_create_email.call_args.kwargs["verify_link"],
+            "https://public.example.org/verify/email",
+        )
 
 
 class AddUserToPanelEndpointTest(TestCase):
@@ -280,6 +313,29 @@ class ChangePasswordTest(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["message"], "If an account exists for this email, a reset link has been sent.")
+
+    @override_settings(
+        PUBLIC_APP_URL="https://public.example.org",
+        ALLOWED_HOSTS=["testserver", "evil.example"],
+    )
+    @patch("gene2phenotype_app.serializers.user.CustomMail.send_reset_email")
+    def test_verify_email_uses_public_app_url(self, mock_send_reset_email):
+        response = self.client.post(
+            self.url_verify_email,
+            {"email": "user5@test.ac.uk"},
+            content_type="application/json",
+            HTTP_HOST="evil.example",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(mock_send_reset_email.call_count, 1)
+        reset_link = mock_send_reset_email.call_args.kwargs["reset_link"]
+        self.assertTrue(
+            reset_link.startswith(
+                "https://public.example.org/gene2phenotype/reset-password/"
+            )
+        )
+        self.assertNotIn("evil.example", reset_link)
 
 
 class TokenRefreshTest(TestCase):

--- a/gene2phenotype_project/gene2phenotype_app/utils/__init__.py
+++ b/gene2phenotype_project/gene2phenotype_app/utils/__init__.py
@@ -11,6 +11,7 @@ from .publication_utils import get_publication, get_authors, clean_title
 from .locus_utils import validate_gene
 from .phenotype_utils import validate_phenotype
 from .user_utils import CustomMail
+from .url_utils import build_public_url
 from .date_utils import get_date_now
 from .curationinfo_utils import ConfidenceCustomMail
 from .lgd_utils import (

--- a/gene2phenotype_project/gene2phenotype_app/utils/curationinfo_utils.py
+++ b/gene2phenotype_project/gene2phenotype_app/utils/curationinfo_utils.py
@@ -3,6 +3,7 @@ from smtplib import SMTP
 from django.conf import settings
 from django.template.loader import render_to_string
 from typing import Dict, Any
+from .url_utils import build_public_url
 
 
 class ConfidenceCustomMail:
@@ -79,10 +80,10 @@ class ConfidenceCustomMail:
         Returns:
             str: url string
         """
-        http_response = self.request.scheme
-        host = self.request.get_host()
-        self.host = host
-        return f"{http_response}://{host}/gene2phenotype/lgd/{self.stable_id}"
+        self.host = settings.PUBLIC_APP_URL.replace("https://", "").replace(
+            "http://", ""
+        ).rstrip("/")
+        return build_public_url(f"/gene2phenotype/lgd/{self.stable_id}")
 
     def get_user_info(self) -> str:
         """

--- a/gene2phenotype_project/gene2phenotype_app/utils/url_utils.py
+++ b/gene2phenotype_project/gene2phenotype_app/utils/url_utils.py
@@ -1,0 +1,10 @@
+from django.conf import settings
+
+
+def build_public_url(path: str) -> str:
+    """
+    Build a public URL using the configured canonical application base URL.
+    """
+    base_url = settings.PUBLIC_APP_URL.rstrip("/")
+    normalized_path = path if path.startswith("/") else f"/{path}"
+    return f"{base_url}{normalized_path}"

--- a/gene2phenotype_project/gene2phenotype_project/settings.py
+++ b/gene2phenotype_project/gene2phenotype_project/settings.py
@@ -34,6 +34,11 @@ DEBUG = config.getboolean("settings", "DEBUG")
 
 ALLOWED_HOSTS = json.loads(config.get("settings", "ALLOWED_HOSTS"))
 
+# Used in the email templates to generate the links to the app
+PUBLIC_APP_URL = config.get(
+    "settings", "PUBLIC_APP_URL", fallback="http://localhost"
+).rstrip("/")
+
 # Application definition
 
 LOGGING = {


### PR DESCRIPTION
### Description ###

This PR removes request-host dependence from externally emailed links and switches those URLs to a configured public base URL defined in settings.py

Tested on the test website.

---

### JIRA Ticket ###

No ticket

---

### Contributor Checklist ###
- [x] The code compiles and runs as expected
- [x] Relevant unit tests are added or updated
- [x] All unit tests are passing
- [x] Code follows the [G2P Coding Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51871986/G2P+Coding+Guidelines)
- [x] Documentation (code comments, confluence, etc.) has been updated as needed

---

### Reviewer Checklist ###
Please **follow the [Code Review Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51937503/Code+Review+Guidelines)** when reviewing this PR.
- [ ] I have followed all review guidelines