### PR TITLE
Set disease max length

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,7 @@ jobs:
           echo "AUTH_COOKIE_SECURE=False" >> /home/runner/work/config.ini
           echo "STATIC_ROOT=" >> /home/runner/work/config.ini
           echo "STATIC_URL=static/" >> /home/runner/work/config.ini
+          echo "MAX_DISEASE_NAME_LENGTH=255" >> /home/runner/work/config.ini
           echo "PUBLIC_APP_URL=http://localhost:5173" >> /home/runner/work/config.ini
           echo "[g2p]" >> /home/runner/work/config.ini
           echo "version=3.0.0" >> /home/runner/work/config.ini

--- a/gene2phenotype_project/gene2phenotype_app/tests/insert_data/test_add_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/insert_data/test_add_disease.py
@@ -38,6 +38,9 @@ class AddDiseaseEndpoint(TestCase):
             "name": "RAB27A-related Griscelli syndrome biallelic"
         }
         self.add_new_disease = {"name": "LDLR-related hypercholesterolaemia"}
+        self.add_too_long_disease = {
+            "name": "LDLR-related " + ("hypercholesterolaemia" * 20)
+        }
         self.add_disease_with_ontology = {
             "name": "STRA6-related syndromic microphthalmia",
             "ontology_terms": [
@@ -169,6 +172,28 @@ class AddDiseaseEndpoint(TestCase):
         response_data = response.json()
         self.assertEqual(
             response_data["name"], ["disease with this name already exists."]
+        )
+
+    def test_add_disease_name_too_long(self):
+        """
+        Test the endpoint rejects a disease name longer than the configured max length.
+        """
+        user = User.objects.get(email="john@test.ac.uk")
+        refresh = RefreshToken.for_user(user)
+        access_token = str(refresh.access_token)
+        self.client.cookies[settings.SIMPLE_JWT["AUTH_COOKIE"]] = access_token
+
+        response = self.client.post(
+            self.url_add_disease,
+            self.add_too_long_disease,
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 400)
+
+        response_data = response.json()
+        self.assertEqual(
+            response_data["name"],
+            ["Ensure this field has no more than 255 characters."],
         )
 
     def test_add_disease_with_invalid_ontology(self):

--- a/gene2phenotype_project/gene2phenotype_app/tests/update_data/test_update_diseases.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/update_data/test_update_diseases.py
@@ -178,6 +178,36 @@ class UpdateDiseasesEndpoint(TestCase):
             "Request should be a list of diseases",
         )
 
+    def test_update_disease_name_too_long(self):
+        """
+        Test updating diseases rejects a name longer than the configured max length.
+        """
+        user = User.objects.get(email="john@test.ac.uk")
+        refresh = RefreshToken.for_user(user)
+        access_token = str(refresh.access_token)
+        self.client.cookies[settings.SIMPLE_JWT["AUTH_COOKIE"]] = access_token
+
+        response = self.client.post(
+            self.url_update,
+            [{"id": 3, "name": "CT87-related " + ("MICROPHTHALMIA" * 25)}],
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 400)
+
+        response_data = response.json()
+        self.assertEqual(
+            response_data["error"],
+            [
+                {
+                    "id": 3,
+                    "name": "CT87-related " + ("MICROPHTHALMIA" * 25),
+                    "error": "Invalid disease name 'CT87-related "
+                    + ("MICROPHTHALMIA" * 25)
+                    + "'",
+                }
+            ],
+        )
+
     def test_update_diseases(self):
         """
         Test updating the disease names

--- a/gene2phenotype_project/gene2phenotype_app/tests/views/test_search.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/views/test_search.py
@@ -306,6 +306,20 @@ class SearchTests(TestCase):
         self.assertEqual(response.status_code, 404)
         self.assertEqual(response.data["error"], "No matching Gene found for: TUBB4A")
 
+    def test_search_gene_with_really_long_query(self):
+        """
+        Test the endpoint rejects a very long search query.
+        """
+        long_query = "TUBB4A" * 300
+        url_search_gene = f"{self.base_url_search}?type=gene&query={long_query}"
+        response = self.client.get(url_search_gene)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data["error"],
+            "Search query is too long. Maximum length is 255 characters.",
+        )
+
     def test_search_not_found_2(self):
         """
         Test the response when not found because the record is deleted

--- a/gene2phenotype_project/gene2phenotype_app/utils/disease_utils.py
+++ b/gene2phenotype_project/gene2phenotype_app/utils/disease_utils.py
@@ -4,6 +4,8 @@ import re
 import requests
 from typing import Optional, Union
 
+from django.conf import settings
+
 
 def latin2arab(match: re.Match[str]) -> str:
     """
@@ -119,9 +121,12 @@ def clean_omim_disease(name: str) -> str:
 
 def validate_disease_name(name: str) -> bool:
     """
-    Validate that the disease name follows the dyadic format.
+    Validate that the disease name follows the length constraint and the dyadic format.
     """
     flag = True
+
+    if len(name) > settings.MAX_DISEASE_NAME_LENGTH:
+        flag = False
 
     name_pattern = re.compile(
         # forbid duplicate ocurrences of gene-related

--- a/gene2phenotype_project/gene2phenotype_app/views/search.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/search.py
@@ -1,5 +1,7 @@
 from functools import reduce
 from operator import or_
+from django.conf import settings
+from rest_framework import status
 from rest_framework.response import Response
 from django.db.models import Q, F
 import textwrap, re
@@ -419,6 +421,15 @@ class SearchView(BaseView):
         """
         search_query = request.query_params.get("query", None)
         search_type = request.query_params.get("type", None)
+
+        if search_query and len(search_query.strip()) > settings.MAX_DISEASE_NAME_LENGTH:
+            return Response(
+                {
+                    "error": "Search query is too long. "
+                    f"Maximum length is {settings.MAX_DISEASE_NAME_LENGTH} characters."
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         # Check if query is a merged or deleted record
         if search_type == "stable_id" or (

--- a/gene2phenotype_project/gene2phenotype_project/settings.py
+++ b/gene2phenotype_project/gene2phenotype_project/settings.py
@@ -34,6 +34,12 @@ DEBUG = config.getboolean("settings", "DEBUG")
 
 ALLOWED_HOSTS = json.loads(config.get("settings", "ALLOWED_HOSTS"))
 
+# Maximum length of the disease name
+# Used to limit the disease name when creating, updating or searching
+MAX_DISEASE_NAME_LENGTH = config.getint(
+    "settings", "MAX_DISEASE_NAME_LENGTH", fallback=255
+)
+
 # Used in the email templates to generate the links to the app
 PUBLIC_APP_URL = config.get(
     "settings", "PUBLIC_APP_URL", fallback="http://localhost"


### PR DESCRIPTION
### Description ###

Set a disease max length `MAX_DISEASE_NAME_LENGTH`. 255 is the max length defined in the db schema.
Use it when validating the disease name and also use it to define the max query search.
Defining a max length helps to fix this issue https://github.com/EBI-G2P/gene2phenotype_api/security/code-scanning/15

---

### JIRA Ticket ###

No ticket

---

### Contributor Checklist ###
- [ ] The code compiles and runs as expected
- [ ] Relevant unit tests are added or updated
- [ ] All unit tests are passing
- [ ] Code follows the [G2P Coding Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51871986/G2P+Coding+Guidelines)
- [ ] Documentation (code comments, confluence, etc.) has been updated as needed

---

### Reviewer Checklist ###
Please **follow the [Code Review Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51937503/Code+Review+Guidelines)** when reviewing this PR.
- [ ] I have followed all review guidelines