### PR TITLE
Update search to return automatic drafts owned by g2p admin

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/tests/views/test_search.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/views/test_search.py
@@ -301,6 +301,9 @@ class SearchTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["count"], 2)
+        self.assertEqual(
+            {result["status"] for result in response.data["results"]}, {"automatic"}
+        )
 
     def test_search_all(self):
         """

--- a/gene2phenotype_project/gene2phenotype_app/tests/views/test_search.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/views/test_search.py
@@ -13,6 +13,7 @@ class SearchTests(TestCase):
     """
 
     fixtures = [
+        "gene2phenotype_app/fixtures/auth_groups.json",
         "gene2phenotype_app/fixtures/locus.json",
         "gene2phenotype_app/fixtures/attribs.json",
         "gene2phenotype_app/fixtures/source.json",
@@ -264,7 +265,7 @@ class SearchTests(TestCase):
 
     def test_search_draft_not_found_manual(self):
         """
-        Test the response when searching a draft which is not of status 'manual'
+        Test automatic drafts are excluded when the owner is not in g2p_admin.
         """
         # Login
         user = User.objects.get(email="user5@test.ac.uk")
@@ -282,6 +283,24 @@ class SearchTests(TestCase):
         # So, the endpoint should return an error
         self.assertEqual(response.status_code, 404)
         self.assertEqual(response.data["error"], "No matching draft found for: MPI")
+
+    def test_search_draft_automatic_for_g2p_admin(self):
+        """
+        Test automatic drafts are included when the owner is in g2p_admin.
+        """
+        # Login
+        user = User.objects.get(email="user5@test.ac.uk")
+        refresh = RefreshToken.for_user(user)
+        access_token = str(refresh.access_token)
+
+        # Authenticate by setting cookie on the test client
+        self.client.cookies[settings.SIMPLE_JWT["AUTH_COOKIE"]] = access_token
+
+        url_search_id = f"{self.base_url_search}?type=draft&query=TUBB4A"
+        response = self.client.get(url_search_id)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["count"], 2)
 
     def test_search_all(self):
         """

--- a/gene2phenotype_project/gene2phenotype_app/views/search.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/search.py
@@ -357,9 +357,12 @@ class SearchView(BaseView):
             # to extend the queryset being annotated when it is draft,
             # we want to return username so curator can see who is curating
             # also add the curator email, incase of the notification
-            # Should search for only manual curations
+            # Return all manual curations and automatic curations owned by g2p admins.
             queryset = (
-                CurationData.objects.filter(gene_symbol=search_query, status="manual")
+                CurationData.objects.filter(gene_symbol=search_query).filter(
+                    Q(status="manual")
+                    | Q(status="automatic", user__groups__name="g2p_admin")
+                )
                 .order_by("stable_id__stable_id")
                 .distinct()
                 .annotate(

--- a/gene2phenotype_project/gene2phenotype_app/views/search.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/search.py
@@ -480,6 +480,7 @@ class SearchView(BaseView):
                 data = {
                     "stable_id": c_data.stable_id.stable_id,
                     "gene": c_data.gene_symbol,
+                    "status": c_data.status,
                     "date_created": c_data.date_created,
                     "date_last_updated": c_data.date_last_update,
                     "curator_first": c_data.first_name,


### PR DESCRIPTION
### Description ###

Endpoint: `gene2phenotype/api/search/?query=TNNI3&type=draft`
Now it also returns automatic drafts owned by g2p admin.

---

### JIRA Ticket ###

No ticket

---

### Contributor Checklist ###
- [x] The code compiles and runs as expected
- [x] Relevant unit tests are added or updated
- [x] All unit tests are passing
- [x] Code follows the [G2P Coding Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51871986/G2P+Coding+Guidelines)
- [x] Documentation (code comments, confluence, etc.) has been updated as needed

---

### Reviewer Checklist ###
Please **follow the [Code Review Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51937503/Code+Review+Guidelines)** when reviewing this PR.
- [ ] I have followed all review guidelines