### PR TITLE
Add private comment when publishing record owned by junior curator

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/serializers/curation.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/curation.py
@@ -462,7 +462,12 @@ class CurationDataSerializer(serializers.ModelSerializer):
         Args:
             data: CurationData object to publish (JSON format)
         """
+        # user that is publishing the record, not necessarily the same user that created the draft
         user = self.context.get("user")
+
+        # Check if user that created draft is a junior curator
+        is_junior_curator = self.context.get("is_junior_curator", False)
+
         publications_list = []
 
         # Get user object
@@ -814,6 +819,17 @@ class CurationDataSerializer(serializers.ModelSerializer):
             }
             LGDCommentSerializer(context={"lgd": lgd_obj, "user": user_obj}).create(
                 comment_obj_private
+            )
+
+        # If user attached to the draft is a junior curator, add a comment to
+        # indicate that the record was reviewed by another curator
+        if is_junior_curator:
+            comment_obj_review = {
+                "comment": f"Record created by {data.user.first_name} {data.user.last_name} and reviewed by {user_obj.first_name} {user_obj.last_name}.",
+                "is_public": 0,
+            }
+            LGDCommentSerializer(context={"lgd": lgd_obj, "user": user_obj}).create(
+                comment_obj_review
             )
 
         # Update stable_id status to live (is_live=1)

--- a/gene2phenotype_project/gene2phenotype_app/tests/curation/test_publish.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/curation/test_publish.py
@@ -5,6 +5,7 @@ from rest_framework_simplejwt.tokens import RefreshToken
 from gene2phenotype_app.models import (
     User,
     LocusGenotypeDisease,
+    LGDComment,
     LGDPublication,
     LGDPublicationComment,
 )
@@ -585,6 +586,69 @@ class LGDAddCurationEndpoint(TestCase):
             lgd_publication=lgd_publications[0], is_deleted=0
         )
         self.assertEqual(len(lgd_publication_comments), 1)
+
+        lgd_comments = LGDComment.objects.filter(lgd=lgd_obj, is_deleted=0)
+        self.assertEqual(len(lgd_comments), 2)
+        self.assertFalse(
+            lgd_comments.filter(comment__contains="reviewed by").exists()
+        )
+
+    def test_publish_junior_curator_record_adds_review_comment(self):
+        """
+        Test publishing a junior curator draft as a senior curator adds the
+        private review comment.
+        """
+        self.login_junior_user()
+        data_to_add = self.get_publishable_curation_payload(
+            session_name="Test junior review publish",
+            disease_name="SRY-related 46,xx sex reversal junior review",
+        )
+
+        response = self.client.post(
+            self.url_add_curation, data_to_add, content_type="application/json"
+        )
+        self.assertEqual(response.status_code, 200)
+
+        response_data = response.json()
+        self.assertEqual(
+            response_data["message"],
+            "Data saved successfully for session name 'Test junior review publish'",
+        )
+
+        self.login_user()
+        url_publish = reverse(
+            "publish_record", kwargs={"stable_id": response_data["result"]}
+        )
+
+        response_publish = self.client.post(
+            url_publish, content_type="application/json"
+        )
+        self.assertEqual(response_publish.status_code, 201)
+        response_data_publish = response_publish.json()
+        self.assertEqual(
+            response_data_publish["message"],
+            "Record 'G2P00017' published successfully",
+        )
+
+        lgd_obj = LocusGenotypeDisease.objects.get(
+            locus__name="SRY",
+            disease__name="SRY-related 46,xx sex reversal junior review",
+            genotype__value="monoallelic_Y_hemizygous",
+            is_deleted=0,
+        )
+
+        lgd_comments = LGDComment.objects.filter(lgd=lgd_obj, is_deleted=0)
+        self.assertEqual(len(lgd_comments), 3)
+
+        review_comment = LGDComment.objects.get(
+            lgd=lgd_obj,
+            is_deleted=0,
+            is_public=0,
+            comment=(
+                "Record created by Elisa Stevens and reviewed by Test User5."
+            ),
+        )
+        self.assertEqual(review_comment.user.email, "user5@test.ac.uk")
 
     def test_publish_unauthorised_access(self):
         """

--- a/gene2phenotype_project/gene2phenotype_app/views/curation.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/curation.py
@@ -541,9 +541,14 @@ class PublishRecord(BaseUpdate):
             # Check if there is enough data to publish the record
             self.serializer_class().validate_to_publish(curation_obj)
 
+            # Check if user that created draft is a junior curator
+            is_junior_curator = curation_obj.user.groups.filter(name="junior_curator").exists()
+
             # Publish record
             try:
-                lgd_obj, check = self.serializer_class(context={"user": user}).publish(
+                # 'user' is the curator that publishes the record
+                # 'is_junior_curator' is used to determine if the user that created the draft is a junior curator
+                lgd_obj, check = self.serializer_class(context={"user": user, "is_junior_curator": is_junior_curator}).publish(
                     curation_obj
                 )
                 # Delete entry from 'curation_data'


### PR DESCRIPTION
### Description ###

If the user linked to the draft curator belongs to group 'junior_curator' then when the record is published add a private comment to indicate who worked on the record.

---

### JIRA Ticket ###

No ticket

---

### Contributor Checklist ###
- [x] The code compiles and runs as expected
- [x] Relevant unit tests are added or updated
- [x] All unit tests are passing
- [x] Code follows the [G2P Coding Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51871986/G2P+Coding+Guidelines)
- [x] Documentation (code comments, confluence, etc.) has been updated as needed

---

### Reviewer Checklist ###
Please **follow the [Code Review Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51937503/Code+Review+Guidelines)** when reviewing this PR.
- [ ] I have followed all review guidelines