### PR TITLE
Remove method to fetch ontology from OLS API

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/fixtures/gene_disease.json
+++ b/gene2phenotype_project/gene2phenotype_app/fixtures/gene_disease.json
@@ -38,5 +38,25 @@
             "identifier": "MONDO:0012433",
             "source": 3
         }
+    },
+    {
+        "model": "gene2phenotype_app.genedisease",
+        "pk": 5,
+        "fields": {
+            "gene": 3,
+            "disease": "Matthew-Wood syndrome",
+            "identifier": "MONDO:0011010",
+            "source": 3
+        }
+    },
+    {
+        "model": "gene2phenotype_app.genedisease",
+        "pk": 6,
+        "fields": {
+            "gene": 8,
+            "disease": "46,XX sex reversal 1",
+            "identifier": "MONDO:0100250",
+            "source": 3
+        }
     }
 ]

--- a/gene2phenotype_project/gene2phenotype_app/serializers/disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/disease.py
@@ -6,6 +6,7 @@ import re
 
 from ..models import (
     Disease,
+    DiseaseExternal,
     DiseaseOntologyTerm,
     DiseaseSynonym,
     Attrib,
@@ -17,7 +18,6 @@ from ..models import (
 
 from ..utils import (
     clean_string,
-    get_ontology,
     get_ontology_source,
     validate_disease_name,
 )
@@ -390,7 +390,6 @@ class CreateDiseaseSerializer(serializers.ModelSerializer):
                 disease_obj = disease_synonym.disease
 
         if disease_obj is None:
-            # TODO: give disease suggestions
             disease_obj = Disease.objects.create(name=disease_name)
 
         # Get attributes
@@ -399,8 +398,6 @@ class CreateDiseaseSerializer(serializers.ModelSerializer):
         )
         attrib = Attrib.objects.get(value="Data source", type__code="ontology_mapping")
 
-        # Check if ontology is in db
-        # The disease ontology is saved in the db as attrib type 'disease'
         for ontology in ontologies_list:
             ontology_accession = ontology["ontology_term"]["accession"]
             ontology_term = ontology["ontology_term"]["term"]
@@ -408,6 +405,7 @@ class CreateDiseaseSerializer(serializers.ModelSerializer):
 
             if ontology_accession is not None and ontology_term is not None:
                 try:
+                    # Check if ontology is already saved in db (table ontology_term)
                     ontology_obj = OntologyTerm.objects.get(
                         accession=ontology_accession
                     )
@@ -422,53 +420,34 @@ class CreateDiseaseSerializer(serializers.ModelSerializer):
                             }
                         )
 
-                    elif source == "Mondo":
-                        # Check if ontology accession is valid
-                        mondo_disease = get_ontology(ontology_accession, source)
-                        if mondo_disease is None:
-                            raise serializers.ValidationError(
-                                {
-                                    "error": f"Invalid Mondo ID. Please check ID '{ontology_accession}'"
-                                }
-                            )
-                        elif mondo_disease == "query failed":
-                            raise serializers.ValidationError(
-                                {
-                                    "error": f"Cannot query Mondo ID '{ontology_accession}'"
-                                }
-                            )
+                    new_ontology_term = None
+                    # Fetch the disease ID from the G2P db
+                    # External identifiers are stored in the db in: GeneDisease and DiseaseExternal
+                    gene_disease = GeneDisease.objects.filter(identifier=ontology_accession)
+                    if gene_disease.exists():
+                        new_ontology_term = gene_disease.first().disease
+                    else:
+                        external_disease = DiseaseExternal.objects.filter(identifier=ontology_accession)
+                        if external_disease.exists():
+                            new_ontology_term = external_disease.first().disease
 
-                    # Replace '_' from mondo ID
-                    ontology_accession = re.sub(r"\_", ":", ontology_accession)
-                    ontology_term = re.sub(r"\_", ":", ontology_term)
-                    # Insert ontology
-                    if ontology_desc is None and len(mondo_disease["description"]) > 0:
-                        ontology_desc = mondo_disease["description"][0]
+                    if new_ontology_term is None:
+                        raise serializers.ValidationError(
+                            {
+                                "error": f"Invalid {source} ID. Please check ID '{ontology_accession}'"
+                            }
+                        )
 
-                    elif source == "OMIM":
-                        omim_disease = get_ontology(ontology_accession, source)
-                        # TODO: check if we can use the OMIM API in the future
-                        if omim_disease == "query failed":
-                            raise serializers.ValidationError(
-                                {
-                                    "error": f"Cannot query OMIM ID '{ontology_accession}'"
-                                }
-                            )
+                    ontology_term = new_ontology_term
+                    ontology_desc = new_ontology_term
 
-                        if (
-                            ontology_desc is None
-                            and omim_disease is not None
-                            and len(omim_disease["description"]) > 0
-                        ):
-                            ontology_desc = omim_disease["description"][0]
-
-                    source = Source.objects.get(name=source)
+                    source_obj = Source.objects.get(name=source)
 
                     ontology_obj = OntologyTerm.objects.create(
                         accession=ontology_accession,
                         term=ontology_term,
                         description=ontology_desc,
-                        source=source,
+                        source=source_obj,
                         group_type=attrib_disease,
                     )
 

--- a/gene2phenotype_project/gene2phenotype_app/tests/curation/test_publish.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/curation/test_publish.py
@@ -29,6 +29,8 @@ class LGDAddCurationEndpoint(TestCase):
         "gene2phenotype_app/fixtures/ontology_term.json",
         "gene2phenotype_app/fixtures/locus_genotype_disease.json",
         "gene2phenotype_app/fixtures/disease.json",
+        "gene2phenotype_app/fixtures/disease_external.json",
+        "gene2phenotype_app/fixtures/gene_disease.json",
     ]
 
     def setUp(self):

--- a/gene2phenotype_project/gene2phenotype_app/tests/insert_data/test_add_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/insert_data/test_add_disease.py
@@ -19,6 +19,8 @@ class AddDiseaseEndpoint(TestCase):
         "gene2phenotype_app/fixtures/attribs.json",
         "gene2phenotype_app/fixtures/cv_molecular_mechanism.json",
         "gene2phenotype_app/fixtures/disease.json",
+        "gene2phenotype_app/fixtures/disease_external.json",
+        "gene2phenotype_app/fixtures/gene_disease.json",
         "gene2phenotype_app/fixtures/g2p_stable_id.json",
         "gene2phenotype_app/fixtures/lgd_mechanism_evidence.json",
         "gene2phenotype_app/fixtures/lgd_mechanism_synopsis.json",

--- a/gene2phenotype_project/gene2phenotype_app/utils/__init__.py
+++ b/gene2phenotype_project/gene2phenotype_app/utils/__init__.py
@@ -1,6 +1,5 @@
 from .disease_utils import (
     clean_string,
-    get_ontology,
     clean_omim_disease,
     get_ontology_source,
     check_synonyms_disease,

--- a/gene2phenotype_project/gene2phenotype_app/utils/disease_utils.py
+++ b/gene2phenotype_project/gene2phenotype_app/utils/disease_utils.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import re
-import requests
 from typing import Optional, Union
 
 from django.conf import settings
@@ -141,45 +140,6 @@ def validate_disease_name(name: str) -> bool:
         flag = False
 
     return flag
-
-
-def get_ontology(id: str, source: str) -> Union[dict, None]:
-    """
-    Query the Ontology Lookup Service (OLS) API for disease ontology information.
-
-    Input:
-        id (str): The disease identifier to query (e.g. "MONDO:0005148" or "222100")
-        source (str): The ontology source. Supported values are: 'Mondo' and 'OMIM'
-    Output:
-        dict | None:
-            - A dictionary containing the OLS response `doc` if available
-            - None if the source is invalid or no matching record is found
-    """
-    if source.lower() == "mondo":
-        url = f"https://www.ebi.ac.uk/ols4/api/search?q={id}&ontology=mondo&exact=1"
-
-    elif source.lower() == "omim":
-        url = f"https://www.ebi.ac.uk/ols4/api/search?q={id}&ontology=cco"
-
-    else:
-        return None
-
-    r = requests.get(url, headers={"Content-Type": "application/json"})
-
-    if not r.ok:
-        return None
-
-    decoded = r.json()
-
-    if (
-        len(decoded["response"]["docs"]) > 0
-        and "label" in decoded["response"]["docs"][0]
-    ):
-        name = decoded["response"]["docs"][0]
-    else:
-        name = None
-
-    return name
 
 
 def get_ontology_source(id: str) -> Optional[str]:


### PR DESCRIPTION
### Description ###

Remove utils method `get_ontology` that fetches Mondo and OMIM IDs from the OLS API.
Update the code to fetch the IDs from the G2P db (Mondo and OMIM are stored in the G2P db).

This update affects the publish endpoint.

---

### JIRA Ticket ###

No ticket

---

### Contributor Checklist ###
- [x] The code compiles and runs as expected
- [x] Relevant unit tests are added or updated
- [x] All unit tests are passing
- [x] Code follows the [G2P Coding Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51871986/G2P+Coding+Guidelines)
- [x] Documentation (code comments, confluence, etc.) has been updated as needed

---

### Reviewer Checklist ###
Please **follow the [Code Review Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51937503/Code+Review+Guidelines)** when reviewing this PR.
- [ ] I have followed all review guidelines