### PR TITLE
Add data check to return publications overlap for records with same gene

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,9 @@
+# This is a placeholder GitLab CI configuration.
+
+workflow:
+  rules:
+    - when: never
+
+hello-world:
+  script:
+    - echo "Hello, world!"

--- a/gene2phenotype_project/gene2phenotype_app/management/commands/check_data.py
+++ b/gene2phenotype_project/gene2phenotype_app/management/commands/check_data.py
@@ -10,6 +10,7 @@ from .datachecks import (
     check_cross_references,
     check_disease_name,
     check_mondo_single_gene_link,
+    get_records_with_publication_overlap,
     get_similar_records,
 )
 
@@ -70,6 +71,11 @@ class Command(BaseCommand):
             # Check for similar records
             similar_records = get_similar_records()
             for error in similar_records:
+                logger.warning(error)
+
+            # Check for publication overlaps for records sharing the same gene
+            publication_overlap_records = get_records_with_publication_overlap()
+            for error in publication_overlap_records:
                 logger.warning(error)
 
             # Run the disease cross references check

--- a/gene2phenotype_project/gene2phenotype_app/management/commands/check_data.py
+++ b/gene2phenotype_project/gene2phenotype_app/management/commands/check_data.py
@@ -30,6 +30,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         include_warnings = options["include_warnings"]
+        records_overlap_threshold = 0.6  # Set the threshold for publication overlap
 
         print("Running data checks...")
 
@@ -74,7 +75,7 @@ class Command(BaseCommand):
                 logger.warning(error)
 
             # Check for publication overlaps for records sharing the same gene
-            publication_overlap_records = get_records_with_publication_overlap()
+            publication_overlap_records = get_records_with_publication_overlap(records_overlap_threshold)
             for error in publication_overlap_records:
                 logger.warning(error)
 

--- a/gene2phenotype_project/gene2phenotype_app/management/commands/datachecks/SimilarRecords.py
+++ b/gene2phenotype_project/gene2phenotype_app/management/commands/datachecks/SimilarRecords.py
@@ -102,9 +102,7 @@ def get_records_with_publication_overlap():
 
         for index, record in enumerate(records):
             record_publications = publications_by_record.get(record["id"], set())
-            if not record_publications:
-                continue
-            if len(record_publications) == 1:
+            if len(record_publications) <= 1:
                 continue
 
             for candidate in records[index + 1 :]:

--- a/gene2phenotype_project/gene2phenotype_app/management/commands/datachecks/SimilarRecords.py
+++ b/gene2phenotype_project/gene2phenotype_app/management/commands/datachecks/SimilarRecords.py
@@ -128,7 +128,7 @@ def get_records_with_publication_overlap():
                     shared_pmids = ", ".join(sorted(str(pmid) for pmid in shared_publications))
                     errors.append(
                         Error(
-                            f"Records share at least 60% of publications: {record['g2p_id']}, {candidate['g2p_id']}. Shared PMIDs: {shared_pmids}",
+                            f"Records share at least {overlap_threshold:.0%} of publications: {record['g2p_id']}, {candidate['g2p_id']}. Shared PMIDs: {shared_pmids}",
                             id="gene2phenotype_app.E602",
                         )
                     )

--- a/gene2phenotype_project/gene2phenotype_app/management/commands/datachecks/SimilarRecords.py
+++ b/gene2phenotype_project/gene2phenotype_app/management/commands/datachecks/SimilarRecords.py
@@ -1,7 +1,9 @@
 from django.core.checks import Error
 from django.db.models import F
 
-from gene2phenotype_app.models import LocusGenotypeDisease
+from gene2phenotype_app.models import LGDPanel, LGDPublication, LocusGenotypeDisease
+
+from .Base import should_process
 
 
 def get_similar_records():
@@ -49,5 +51,90 @@ def get_similar_records():
                         id="gene2phenotype_app.E601",
                     )
                 )
+
+    return errors
+
+
+def get_records_with_publication_overlap():
+    """Check for non-deleted records sharing at least 60% of publications within a locus."""
+    errors = []
+    overlap_threshold = 0.6
+    records_by_locus = {}
+    panels_by_record = {}
+    publications_by_record = {}
+
+    lgd_records = (
+        LocusGenotypeDisease.objects.annotate(g2p_id=F("stable_id__stable_id"))
+        .filter(is_deleted=0)
+        .values("id", "g2p_id", "locus_id", "disease_id", "genotype_id", "mechanism_id")
+    )
+
+    for obj in lgd_records:
+        if not should_process(obj["id"]):
+            continue
+
+        records_by_locus.setdefault(obj["locus_id"], []).append(
+            {
+                "id": obj["id"],
+                "g2p_id": obj["g2p_id"],
+                "disease_id": obj["disease_id"],
+                "genotype_id": obj["genotype_id"],
+                "mechanism_id": obj["mechanism_id"],
+            }
+        )
+
+    lgd_panels = LGDPanel.objects.filter(is_deleted=0).values("lgd_id", "panel_id")
+    for obj in lgd_panels:
+        panels_by_record.setdefault(obj["lgd_id"], set()).add(obj["panel_id"])
+
+    lgd_publications = (
+        LGDPublication.objects.annotate(pmid=F("publication__pmid"))
+        .filter(is_deleted=0, lgd__is_deleted=0)
+        .values("lgd_id", "pmid")
+    )
+
+    for obj in lgd_publications:
+        publications_by_record.setdefault(obj["lgd_id"], set()).add(obj["pmid"])
+
+    for records in records_by_locus.values():
+        if len(records) < 2:
+            continue
+
+        for index, record in enumerate(records):
+            record_publications = publications_by_record.get(record["id"], set())
+            if not record_publications:
+                continue
+
+            for candidate in records[index + 1 :]:
+                same_disease = record["disease_id"] == candidate["disease_id"]
+                different_genotype = record["genotype_id"] != candidate["genotype_id"]
+                same_mechanism = record["mechanism_id"] == candidate["mechanism_id"]
+                shared_panels = panels_by_record.get(record["id"], set()) & panels_by_record.get(
+                    candidate["id"], set()
+                )
+                if same_disease and different_genotype and same_mechanism and shared_panels:
+                    continue
+
+                candidate_publications = publications_by_record.get(candidate["id"], set())
+                if not candidate_publications:
+                    continue
+
+                shared_publications = record_publications & candidate_publications
+                minimum_publications = min(
+                    len(record_publications), len(candidate_publications)
+                )
+
+                if minimum_publications == 0:
+                    continue
+
+                overlap = len(shared_publications) / minimum_publications
+                if overlap >= overlap_threshold:
+                    shared_pmids = ", ".join(sorted(str(pmid) for pmid in shared_publications))
+                    errors.append(
+                        Error(
+                            f"Records share at least 60% of publications: {record['g2p_id']}, {candidate['g2p_id']}. Shared PMIDs: {shared_pmids}",
+                            id="gene2phenotype_app.E602",
+                        )
+                    )
 
     return errors

--- a/gene2phenotype_project/gene2phenotype_app/management/commands/datachecks/SimilarRecords.py
+++ b/gene2phenotype_project/gene2phenotype_app/management/commands/datachecks/SimilarRecords.py
@@ -112,9 +112,7 @@ def get_records_with_publication_overlap():
                     continue
 
                 candidate_publications = publications_by_record.get(candidate["id"], set())
-                if not candidate_publications:
-                    continue
-                if len(candidate_publications) == 1:
+                if len(candidate_publications) <= 1:
                     continue
 
                 shared_publications = record_publications & candidate_publications

--- a/gene2phenotype_project/gene2phenotype_app/management/commands/datachecks/SimilarRecords.py
+++ b/gene2phenotype_project/gene2phenotype_app/management/commands/datachecks/SimilarRecords.py
@@ -106,13 +106,9 @@ def get_records_with_publication_overlap():
                 continue
 
             for candidate in records[index + 1 :]:
-                same_disease = record["disease_id"] == candidate["disease_id"]
-                different_genotype = record["genotype_id"] != candidate["genotype_id"]
-                same_mechanism = record["mechanism_id"] == candidate["mechanism_id"]
-                shared_panels = panels_by_record.get(record["id"], set()) & panels_by_record.get(
-                    candidate["id"], set()
-                )
-                if same_disease and different_genotype and same_mechanism and shared_panels:
+                if record["disease_id"] == candidate["disease_id"]:
+                    continue
+                if record["genotype_id"] != candidate["genotype_id"]:
                     continue
 
                 candidate_publications = publications_by_record.get(candidate["id"], set())

--- a/gene2phenotype_project/gene2phenotype_app/management/commands/datachecks/SimilarRecords.py
+++ b/gene2phenotype_project/gene2phenotype_app/management/commands/datachecks/SimilarRecords.py
@@ -55,10 +55,9 @@ def get_similar_records():
     return errors
 
 
-def get_records_with_publication_overlap():
-    """Check for non-deleted records sharing at least 60% of publications within a locus."""
+def get_records_with_publication_overlap(overlap_threshold):
+    """Check for non-deleted records sharing a specified threshold of publications within a locus."""
     errors = []
-    overlap_threshold = 0.6
     records_by_locus = {}
     panels_by_record = {}
     publications_by_record = {}

--- a/gene2phenotype_project/gene2phenotype_app/management/commands/datachecks/SimilarRecords.py
+++ b/gene2phenotype_project/gene2phenotype_app/management/commands/datachecks/SimilarRecords.py
@@ -104,6 +104,8 @@ def get_records_with_publication_overlap():
             record_publications = publications_by_record.get(record["id"], set())
             if not record_publications:
                 continue
+            if len(record_publications) == 1:
+                continue
 
             for candidate in records[index + 1 :]:
                 if record["disease_id"] == candidate["disease_id"]:
@@ -113,6 +115,8 @@ def get_records_with_publication_overlap():
 
                 candidate_publications = publications_by_record.get(candidate["id"], set())
                 if not candidate_publications:
+                    continue
+                if len(candidate_publications) == 1:
                     continue
 
                 shared_publications = record_publications & candidate_publications

--- a/gene2phenotype_project/gene2phenotype_app/management/commands/datachecks/__init__.py
+++ b/gene2phenotype_project/gene2phenotype_app/management/commands/datachecks/__init__.py
@@ -14,4 +14,7 @@ from .Disease import (
 
 from .MinedPublications import check_mined_publication_status
 
-from .SimilarRecords import get_similar_records
+from .SimilarRecords import (
+    get_records_with_publication_overlap,
+    get_similar_records,
+)

--- a/gene2phenotype_project/gene2phenotype_app/serializers/panel.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/panel.py
@@ -107,7 +107,10 @@ class PanelDetailSerializer(serializers.ModelSerializer):
 
         queryset = (
             LGDPanel.objects.filter(
-                panel=id, lgd__is_deleted=0, lgd__date_review__isnull=False
+                panel=id,
+                is_deleted=0,
+                lgd__is_deleted=0,
+                lgd__date_review__isnull=False
             )
             .select_related("lgd")
             .order_by("-lgd__date_review")
@@ -128,7 +131,7 @@ class PanelDetailSerializer(serializers.ModelSerializer):
             - total number of records by confidence
         """
         lgd_panels = LGDPanel.objects.filter(
-            panel=panel.id, is_deleted=0
+            panel=panel.id, is_deleted=0, lgd__is_deleted=0
         ).select_related()
 
         genes = set()

--- a/gene2phenotype_project/gene2phenotype_app/tests/views/test_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/views/test_disease.py
@@ -166,17 +166,23 @@ class DiseaseSummaryTests(TestCase):
             response.data["disease"], "RAB27A-related Griscelli syndrome"
         )
 
-        expected_data = {
-            "locus": "RAB27A",
-            "genotype": "biallelic_autosomal",
-            "confidence": "definitive",
-            "panels": ["Cardiac"],
-            "variant_consequence": ["absent gene product"],
-            "variant_type": ["inframe_insertion", "intron_variant"],
-            "molecular_mechanism": "loss of function",
-            "stable_id": "G2P00002",
-        }
-        self.assertEqual(list(response.data["records_summary"])[0], expected_data)
+        record = next(
+            item
+            for item in response.data["records_summary"]
+            if item["stable_id"] == "G2P00002"
+        )
+
+        self.assertEqual(record["locus"], "RAB27A")
+        self.assertEqual(record["genotype"], "biallelic_autosomal")
+        self.assertEqual(record["confidence"], "definitive")
+        self.assertEqual(record["molecular_mechanism"], "loss of function")
+        self.assertCountEqual(record["panels"], ["Cardiac"])
+        self.assertCountEqual(
+            record["variant_consequence"], ["absent gene product"]
+        )
+        self.assertCountEqual(
+            record["variant_type"], ["inframe_insertion", "intron_variant"]
+        )
 
     def test_get_disease_with_only_deleted_variant_consequence(self):
         """
@@ -197,7 +203,7 @@ class DiseaseSummaryTests(TestCase):
             if item["stable_id"] == "G2P00002"
         )
         self.assertEqual(record["variant_consequence"], [])
-        self.assertEqual(
+        self.assertCountEqual(
             record["variant_type"], ["inframe_insertion", "intron_variant"]
         )
 

--- a/gene2phenotype_project/gene2phenotype_app/tests/views/test_gene.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/views/test_gene.py
@@ -35,7 +35,7 @@ class GeneEndpointTests(TestCase):
         self.assertEqual(response.data["ids"], expected_data_ids)
 
         expected_data_synonyms = ["BBS14", "CT87"]
-        self.assertEqual(list(response.data["synonyms"]), expected_data_synonyms)
+        self.assertCountEqual(response.data["synonyms"], expected_data_synonyms)
 
 
 class GeneSummaryEndpointTests(TestCase):
@@ -101,19 +101,24 @@ class GeneSummaryEndpointTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
 
-        # The output is sorted by date of review
-        expected_data = {
-            "disease": "RAB27A-related Griscelli syndrome",
-            "genotype": "biallelic_autosomal",
-            "confidence": "definitive",
-            "panels": ["Cardiac"],
-            "variant_consequence": ["absent gene product"],
-            "variant_type": ["inframe_insertion", "intron_variant"],
-            "molecular_mechanism": "loss of function",
-            "last_updated": "2018-07-05",
-            "stable_id": "G2P00002",
-        }
-        self.assertEqual(list(response.data["records_summary"])[1], expected_data)
+        record = next(
+            item
+            for item in response.data["records_summary"]
+            if item["stable_id"] == "G2P00002"
+        )
+
+        self.assertEqual(record["disease"], "RAB27A-related Griscelli syndrome")
+        self.assertEqual(record["genotype"], "biallelic_autosomal")
+        self.assertEqual(record["confidence"], "definitive")
+        self.assertEqual(record["molecular_mechanism"], "loss of function")
+        self.assertEqual(record["last_updated"], "2018-07-05")
+        self.assertCountEqual(record["panels"], ["Cardiac"])
+        self.assertCountEqual(
+            record["variant_consequence"], ["absent gene product"]
+        )
+        self.assertCountEqual(
+            record["variant_type"], ["inframe_insertion", "intron_variant"]
+        )
 
     def test_get_summary_with_only_deleted_variant_consequence(self):
         """
@@ -131,7 +136,7 @@ class GeneSummaryEndpointTests(TestCase):
             if item["stable_id"] == "G2P00002"
         )
         self.assertEqual(record["variant_consequence"], [])
-        self.assertEqual(
+        self.assertCountEqual(
             record["variant_type"], ["inframe_insertion", "intron_variant"]
         )
 
@@ -250,7 +255,7 @@ class GeneDiseaseEndpointTests(TestCase):
                 "source": "Mondo",
             },
         ]
-        self.assertEqual(response.data["results"], expected_data_function)
+        self.assertCountEqual(response.data["results"], expected_data_function)
 
     def test_get_gene_synonym(self):
         """
@@ -287,7 +292,7 @@ class GeneDiseaseEndpointTests(TestCase):
                 "source": "Mondo",
             },
         ]
-        self.assertEqual(response.data["results"], expected_data_function)
+        self.assertCountEqual(response.data["results"], expected_data_function)
 
     def test_get_invalid_gene(self):
         """

--- a/gene2phenotype_project/gene2phenotype_app/tests/views/test_panel.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/views/test_panel.py
@@ -343,11 +343,11 @@ class PanelDownloadEndpointTests(TestCase):
         self.assertIn("g2p id", rows[0])
 
         row = next(row for row in rows[1:] if row[0] == "G2P00002")
-        expected_summary = (
+        expected_summary_prefix = (
             "RAB27A-related Griscelli syndrome has a confidence assertion of definitive based on 2 curated publications. "
             "This is a biallelic autosomal condition. This is typically de novo and this is typified by incomplete penetrance. "
             "Variant consequence is absent gene product (inferred). Molecular mechanism is loss of function (evidenced by protein "
-            "interaction function). Recorded variant types include inframe insertion and intron variant."
+            "interaction function). Recorded variant types include "
         )
 
         self.assertEqual(row[0], "G2P00002")
@@ -374,7 +374,14 @@ class PanelDownloadEndpointTests(TestCase):
         )
         self.assertEqual(row[22], "2018-07-05 16:33:03+00:00")
         self.assertEqual(row[23], "under review")
-        self.assertEqual(row[24], expected_summary)
+        self.assertTrue(row[24].startswith(expected_summary_prefix))
+        self.assertIn(
+            row[24][len(expected_summary_prefix) :],
+            {
+                "inframe insertion and intron variant.",
+                "intron variant and inframe insertion.",
+            },
+        )
         self.assertCountEqual(row[4].split("; "), ["GS2", "RAB27"])
         self.assertCountEqual(
             row[12].split("; "), ["inframe_insertion", "intron_variant"]

--- a/gene2phenotype_project/gene2phenotype_app/tests/views/test_panel.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/views/test_panel.py
@@ -169,7 +169,7 @@ class PanelSummaryEndpointTests(TestCase):
             if item["stable_id"] == "G2P00002"
         )
         self.assertEqual(record["variant_consequence"], [])
-        self.assertEqual(
+        self.assertCountEqual(
             record["variant_type"], ["inframe_insertion", "intron_variant"]
         )
 
@@ -279,34 +279,44 @@ class PanelDownloadEndpointTests(TestCase):
         self.assertEqual(len(rows), 6)
         self.assertIn("g2p id", rows[0])
 
-        expected_data = [
-            "G2P00002",
-            "RAB27A",
-            "",
-            "9766",
-            "GS2; RAB27",
-            "RAB27A-related Griscelli syndrome",
-            "",
-            "",
-            "biallelic_autosomal",
-            "typified by incomplete penetrance; typically de novo",
-            "definitive",
-            "absent gene product",
-            "inframe_insertion; intron_variant",
-            "loss of function",
-            "evidence",
-            "assembly-mediated GOF:inferred; aggregation:inferred",
-            "15214012 -> function: protein interaction",
-            "HP:0003549; HP:0010786; HP:0033127",
-            "12451214; 15214012",
-            "32302040",
-            "Cardiac",
-            "All mutations are located in the aminoterminal part of the gene, before the first epidermal growth factor-like domain.",
-            "2018-07-05 16:33:03+00:00",
-            "under review",
-        ]
+        row = next(row for row in rows[1:] if row[0] == "G2P00002")
 
-        self.assertEqual(rows[2], expected_data)
+        self.assertEqual(row[0], "G2P00002")
+        self.assertEqual(row[1], "RAB27A")
+        self.assertEqual(row[2], "")
+        self.assertEqual(row[3], "9766")
+        self.assertEqual(row[5], "RAB27A-related Griscelli syndrome")
+        self.assertEqual(row[6], "")
+        self.assertEqual(row[7], "")
+        self.assertEqual(row[8], "biallelic_autosomal")
+        self.assertEqual(
+            row[9], "typified by incomplete penetrance; typically de novo"
+        )
+        self.assertEqual(row[10], "definitive")
+        self.assertEqual(row[11], "absent gene product")
+        self.assertEqual(row[13], "loss of function")
+        self.assertEqual(row[14], "evidence")
+        self.assertEqual(row[16], "15214012 -> function: protein interaction")
+        self.assertEqual(row[19], "32302040")
+        self.assertEqual(row[20], "Cardiac")
+        self.assertEqual(
+            row[21],
+            "All mutations are located in the aminoterminal part of the gene, before the first epidermal growth factor-like domain.",
+        )
+        self.assertEqual(row[22], "2018-07-05 16:33:03+00:00")
+        self.assertEqual(row[23], "under review")
+        self.assertCountEqual(row[4].split("; "), ["GS2", "RAB27"])
+        self.assertCountEqual(
+            row[12].split("; "), ["inframe_insertion", "intron_variant"]
+        )
+        self.assertCountEqual(
+            row[15].split("; "),
+            ["assembly-mediated GOF:inferred", "aggregation:inferred"],
+        )
+        self.assertCountEqual(
+            row[17].split("; "), ["HP:0003549", "HP:0010786", "HP:0033127"]
+        )
+        self.assertCountEqual(row[18].split("; "), ["12451214", "15214012"])
 
     def test_download_all_visible_panel_with_summary(self):
         """
@@ -332,35 +342,48 @@ class PanelDownloadEndpointTests(TestCase):
         self.assertEqual(len(rows), 6)
         self.assertIn("g2p id", rows[0])
 
-        expected_data = [
-            "G2P00002",
-            "RAB27A",
-            "",
-            "9766",
-            "GS2; RAB27",
-            "RAB27A-related Griscelli syndrome",
-            "",
-            "",
-            "biallelic_autosomal",
-            "typified by incomplete penetrance; typically de novo",
-            "definitive",
-            "absent gene product",
-            "inframe_insertion; intron_variant",
-            "loss of function",
-            "evidence",
-            "assembly-mediated GOF:inferred; aggregation:inferred",
-            "15214012 -> function: protein interaction",
-            "HP:0003549; HP:0010786; HP:0033127",
-            "12451214; 15214012",
-            "32302040",
-            "Cardiac",
-            "All mutations are located in the aminoterminal part of the gene, before the first epidermal growth factor-like domain.",
-            "2018-07-05 16:33:03+00:00",
-            "under review",
+        row = next(row for row in rows[1:] if row[0] == "G2P00002")
+        expected_summary = (
             "RAB27A-related Griscelli syndrome has a confidence assertion of definitive based on 2 curated publications. "
             "This is a biallelic autosomal condition. This is typically de novo and this is typified by incomplete penetrance. "
             "Variant consequence is absent gene product (inferred). Molecular mechanism is loss of function (evidenced by protein "
-            "interaction function). Recorded variant types include inframe insertion and intron variant.",
-        ]
+            "interaction function). Recorded variant types include inframe insertion and intron variant."
+        )
 
-        self.assertEqual(rows[2], expected_data)
+        self.assertEqual(row[0], "G2P00002")
+        self.assertEqual(row[1], "RAB27A")
+        self.assertEqual(row[2], "")
+        self.assertEqual(row[3], "9766")
+        self.assertEqual(row[5], "RAB27A-related Griscelli syndrome")
+        self.assertEqual(row[6], "")
+        self.assertEqual(row[7], "")
+        self.assertEqual(row[8], "biallelic_autosomal")
+        self.assertEqual(
+            row[9], "typified by incomplete penetrance; typically de novo"
+        )
+        self.assertEqual(row[10], "definitive")
+        self.assertEqual(row[11], "absent gene product")
+        self.assertEqual(row[13], "loss of function")
+        self.assertEqual(row[14], "evidence")
+        self.assertEqual(row[16], "15214012 -> function: protein interaction")
+        self.assertEqual(row[19], "32302040")
+        self.assertEqual(row[20], "Cardiac")
+        self.assertEqual(
+            row[21],
+            "All mutations are located in the aminoterminal part of the gene, before the first epidermal growth factor-like domain.",
+        )
+        self.assertEqual(row[22], "2018-07-05 16:33:03+00:00")
+        self.assertEqual(row[23], "under review")
+        self.assertEqual(row[24], expected_summary)
+        self.assertCountEqual(row[4].split("; "), ["GS2", "RAB27"])
+        self.assertCountEqual(
+            row[12].split("; "), ["inframe_insertion", "intron_variant"]
+        )
+        self.assertCountEqual(
+            row[15].split("; "),
+            ["assembly-mediated GOF:inferred", "aggregation:inferred"],
+        )
+        self.assertCountEqual(
+            row[17].split("; "), ["HP:0003549", "HP:0010786", "HP:0033127"]
+        )
+        self.assertCountEqual(row[18].split("; "), ["12451214", "15214012"])

--- a/gene2phenotype_project/gene2phenotype_app/views/panel.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/panel.py
@@ -1,9 +1,10 @@
 from rest_framework import generics, status, permissions
+from rest_framework.renderers import BaseRenderer
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from django.http import Http404, HttpResponse
 from django.db.models import Q
-from rest_framework.decorators import api_view
+from rest_framework.decorators import api_view, renderer_classes
 from drf_spectacular.utils import (
     extend_schema,
     OpenApiResponse,
@@ -44,6 +45,16 @@ from gene2phenotype_app.serializers import (
 from .base import BaseAPIView, IsSuperUser, CustomPermissionAPIView
 
 from ..utils import get_date_now
+
+
+class CSVRenderer(BaseRenderer):
+    media_type = "text/csv"
+    format = "csv"
+    charset = "utf-8"
+    render_style = "binary"
+
+    def render(self, data, accepted_media_type=None, renderer_context=None):
+        return data
 
 
 @extend_schema(exclude=True)
@@ -527,6 +538,7 @@ class LGDEditPanel(CustomPermissionAPIView):
     },
 )
 @api_view(["GET"])
+@renderer_classes([CSVRenderer])
 def PanelDownload(request, name):
     """
     Method to download the panel data.

--- a/gene2phenotype_project/gene2phenotype_app/views/panel.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/panel.py
@@ -4,7 +4,12 @@ from rest_framework.response import Response
 from django.http import Http404, HttpResponse
 from django.db.models import Q
 from rest_framework.decorators import api_view
-from drf_spectacular.utils import extend_schema, OpenApiResponse, OpenApiExample
+from drf_spectacular.utils import (
+    extend_schema,
+    OpenApiResponse,
+    OpenApiExample,
+    OpenApiTypes,
+)
 from django.db import transaction
 from django.shortcuts import get_object_or_404
 from datetime import datetime
@@ -514,6 +519,12 @@ class LGDEditPanel(CustomPermissionAPIView):
     - Download DD records:
         `/panel/DD/download`
     """),
+    responses={
+        (200, "text/csv"): OpenApiResponse(
+            response=OpenApiTypes.BINARY,
+            description="Uncompressed CSV export for the selected panel or for all visible panels.",
+        )
+    },
 )
 @api_view(["GET"])
 def PanelDownload(request, name):

--- a/gene2phenotype_project/schema.json
+++ b/gene2phenotype_project/schema.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.3",
     "info": {
         "title": "Gene2Phenotype (G2P)",
-        "version": "15.0.0",
+        "version": "18.0.0",
         "description": "This API enables access to gene disease models held in the G2P database. See [https://www.ebi.ac.uk/gene2phenotype/](https://www.ebi.ac.uk/gene2phenotype/) for more details.<br><br>Contact us by submitting an issue via [https://github.com/EBI-G2P/gene2phenotype_api/issues](https://github.com/EBI-G2P/gene2phenotype_api/issues)."
     },
     "paths": {
@@ -39,6 +39,7 @@
                                 "examples": {
                                     "Example1": {
                                         "value": {
+                                            "summary": "MTFMT-related mitochondrial disease with regression and lactic acidosis has a confidence assertion of definitive based on 5 curated publications. This is a biallelic autosomal condition. Variant consequence is absent gene product (inferred) and altered gene product structure (inferred). Molecular mechanism is loss of function (evidenced by biochemical function, protein expression function, patient cells functional alteration and patient cells rescue). Recorded variant types include splice region variant, frameshift variant, stop gained and missense variant.",
                                             "locus": {
                                                 "gene_symbol": "MTFMT",
                                                 "sequence": "15",
@@ -685,7 +686,15 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "No response body"
+                        "content": {
+                            "text/csv": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "binary"
+                                }
+                            }
+                        },
+                        "description": "Uncompressed CSV export for the selected panel or for all visible panels."
                     }
                 }
             }
@@ -1142,6 +1151,12 @@
                 "type": "object",
                 "description": "Serializer for the LocusGenotypeDisease model.\nLocusGenotypeDisease represents a unique Locus-Genotype-Mechanism-Disease-Evidence (LGMDE) record.",
                 "properties": {
+                    "summary": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "Summary of the LGMDE record.\nThe summary is automatically generated using the record's data.",
+                        "readOnly": true
+                    },
                     "locus": {
                         "type": "object",
                         "additionalProperties": {},
@@ -1312,6 +1327,7 @@
                     "phenotypes",
                     "publications",
                     "stable_id",
+                    "summary",
                     "variant_consequence",
                     "variant_description",
                     "variant_type"


### PR DESCRIPTION
### Description ###

This PR adds a non-critical data check.
The new check flags pairs of records when all of the following are true:
- the records belong to the same locus
- the records have different diseases
- the records have the same genotype
- both records have at least two linked publications
- at least 60% of the smaller publication set is shared

Pairs are skipped if either record has no publications, only one publication or the two records have the same disease or different genotypes.

Command to run:
`python manage.py check_data --include_warnings`

---

### JIRA Ticket ###

[G2P-621](https://embl.atlassian.net/browse/G2P-621)

---

### Contributor Checklist ###
- [x] The code compiles and runs as expected
- [x] Relevant unit tests are added or updated
- [x] All unit tests are passing
- [x] Code follows the [G2P Coding Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51871986/G2P+Coding+Guidelines)
- [x] Documentation (code comments, confluence, etc.) has been updated as needed
