### PR TITLE
G2P-71 - Add data check for active LGD-related records linked to deleted G2P IDs

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/management/commands/check_data.py
+++ b/gene2phenotype_project/gene2phenotype_app/management/commands/check_data.py
@@ -11,6 +11,7 @@ from .datachecks import (
     check_disease_name,
     check_mondo_single_gene_link,
     get_similar_records,
+    check_deleted_records,
 )
 
 logger = logging.getLogger(__name__)
@@ -23,7 +24,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--include_warnings",
             required=False,
-            action='store_true',
+            action="store_true",
             help="Include non-critical data checks",
         )
 
@@ -55,6 +56,10 @@ class Command(BaseCommand):
 
         mondo_gene_errors = check_mondo_single_gene_link()
         for error in mondo_gene_errors:
+            logger.error(error)
+
+        deleted_records_errors = check_deleted_records()
+        for error in deleted_records_errors:
             logger.error(error)
 
         print("Running data checks... done")

--- a/gene2phenotype_project/gene2phenotype_app/management/commands/datachecks/DeletedRecords.py
+++ b/gene2phenotype_project/gene2phenotype_app/management/commands/datachecks/DeletedRecords.py
@@ -1,0 +1,155 @@
+from django.core.checks import Error
+from django.db.models import F
+
+from gene2phenotype_app.models import (
+    LocusGenotypeDisease,
+    LGDComment,
+    LGDCrossCuttingModifier,
+    LGDMolecularMechanismEvidence,
+    LGDMolecularMechanismSynopsis,
+    LGDPanel,
+    LGDPhenotype,
+    LGDPhenotypeSummary,
+    LGDPublication,
+    LGDVariantGenccConsequence,
+    LGDVariantType,
+    LGDVariantTypeDescription,
+)
+
+
+def append_active_records_with_deleted_g2p_ids_error(
+    errors, queryset, g2p_id_field, error_id
+):
+    """Append an error for active records linked to deleted G2P IDs."""
+    table_name = queryset.model._meta.db_table
+    invalid_records = list(
+        queryset.annotate(
+            row_id=F("id"),
+            g2p_id=F(g2p_id_field),
+        ).values("row_id", "g2p_id")
+    )
+
+    if invalid_records:
+        errors.append(
+            Error(
+                f"Active records in {table_name} linked to deleted G2P IDs: "
+                + ", ".join(
+                    f"ID {record['row_id']} (G2P ID {record['g2p_id']})"
+                    for record in invalid_records
+                ),
+                id=error_id,
+            )
+        )
+
+
+def check_deleted_records():
+    """Check LGD-related tables for active records linked to deleted G2P IDs."""
+    errors = []
+
+    # Check active records linked to deleted G2P IDs in LocusGenotypeDisease objects
+    append_active_records_with_deleted_g2p_ids_error(
+        errors,
+        LocusGenotypeDisease.objects.filter(stable_id__is_deleted=1, is_deleted=0),
+        "stable_id__stable_id",
+        "gene2phenotype_app.E701",
+    )
+
+    # Check active records linked to deleted G2P IDs in LGDMolecularMechanismSynopsis objects
+    append_active_records_with_deleted_g2p_ids_error(
+        errors,
+        LGDMolecularMechanismSynopsis.objects.filter(
+            lgd__stable_id__is_deleted=1, is_deleted=0
+        ),
+        "lgd__stable_id__stable_id",
+        "gene2phenotype_app.E702",
+    )
+
+    # Check active records linked to deleted G2P IDs in LGDMolecularMechanismEvidence objects
+    append_active_records_with_deleted_g2p_ids_error(
+        errors,
+        LGDMolecularMechanismEvidence.objects.filter(
+            lgd__stable_id__is_deleted=1, is_deleted=0
+        ),
+        "lgd__stable_id__stable_id",
+        "gene2phenotype_app.E703",
+    )
+
+    # Check active records linked to deleted G2P IDs in LGDCrossCuttingModifier objects
+    append_active_records_with_deleted_g2p_ids_error(
+        errors,
+        LGDCrossCuttingModifier.objects.filter(
+            lgd__stable_id__is_deleted=1, is_deleted=0
+        ),
+        "lgd__stable_id__stable_id",
+        "gene2phenotype_app.E704",
+    )
+
+    # Check active records linked to deleted G2P IDs in LGDPhenotype objects
+    append_active_records_with_deleted_g2p_ids_error(
+        errors,
+        LGDPhenotype.objects.filter(lgd__stable_id__is_deleted=1, is_deleted=0),
+        "lgd__stable_id__stable_id",
+        "gene2phenotype_app.E705",
+    )
+
+    # Check active records linked to deleted G2P IDs in LGDPhenotypeSummary objects
+    append_active_records_with_deleted_g2p_ids_error(
+        errors,
+        LGDPhenotypeSummary.objects.filter(lgd__stable_id__is_deleted=1, is_deleted=0),
+        "lgd__stable_id__stable_id",
+        "gene2phenotype_app.E706",
+    )
+
+    # Check active records linked to deleted G2P IDs in LGDVariantType objects
+    append_active_records_with_deleted_g2p_ids_error(
+        errors,
+        LGDVariantType.objects.filter(lgd__stable_id__is_deleted=1, is_deleted=0),
+        "lgd__stable_id__stable_id",
+        "gene2phenotype_app.E707",
+    )
+
+    # Check active records linked to deleted G2P IDs in LGDVariantTypeDescription objects
+    append_active_records_with_deleted_g2p_ids_error(
+        errors,
+        LGDVariantTypeDescription.objects.filter(
+            lgd__stable_id__is_deleted=1, is_deleted=0
+        ),
+        "lgd__stable_id__stable_id",
+        "gene2phenotype_app.E708",
+    )
+
+    # Check active records linked to deleted G2P IDs in LGDVariantGenccConsequence objects
+    append_active_records_with_deleted_g2p_ids_error(
+        errors,
+        LGDVariantGenccConsequence.objects.filter(
+            lgd__stable_id__is_deleted=1, is_deleted=0
+        ),
+        "lgd__stable_id__stable_id",
+        "gene2phenotype_app.E709",
+    )
+
+    # Check active records linked to deleted G2P IDs in LGDComment objects
+    append_active_records_with_deleted_g2p_ids_error(
+        errors,
+        LGDComment.objects.filter(lgd__stable_id__is_deleted=1, is_deleted=0),
+        "lgd__stable_id__stable_id",
+        "gene2phenotype_app.E710",
+    )
+
+    # Check active records linked to deleted G2P IDs in LGDPublication objects
+    append_active_records_with_deleted_g2p_ids_error(
+        errors,
+        LGDPublication.objects.filter(lgd__stable_id__is_deleted=1, is_deleted=0),
+        "lgd__stable_id__stable_id",
+        "gene2phenotype_app.E711",
+    )
+
+    # Check active records linked to deleted G2P IDs in LGDPanel objects
+    append_active_records_with_deleted_g2p_ids_error(
+        errors,
+        LGDPanel.objects.filter(lgd__stable_id__is_deleted=1, is_deleted=0),
+        "lgd__stable_id__stable_id",
+        "gene2phenotype_app.E712",
+    )
+
+    return errors

--- a/gene2phenotype_project/gene2phenotype_app/management/commands/datachecks/DeletedRecords.py
+++ b/gene2phenotype_project/gene2phenotype_app/management/commands/datachecks/DeletedRecords.py
@@ -18,15 +18,15 @@ from gene2phenotype_app.models import (
 
 
 def append_active_records_with_deleted_g2p_ids_error(
-    errors, queryset, g2p_id_field, error_id
+    errors, queryset, lgd_id_field, g2p_id_field, error_id
 ):
     """Append an error for active records linked to deleted G2P IDs."""
     table_name = queryset.model._meta.db_table
     invalid_records = list(
         queryset.annotate(
-            row_id=F("id"),
-            g2p_id=F(g2p_id_field),
-        ).values("row_id", "g2p_id")
+            record_lgd_id=F(lgd_id_field),
+            deleted_g2p_stable_id=F(g2p_id_field),
+        ).values("record_lgd_id", "deleted_g2p_stable_id")
     )
 
     if invalid_records:
@@ -34,7 +34,7 @@ def append_active_records_with_deleted_g2p_ids_error(
             Error(
                 f"Active records in {table_name} linked to deleted G2P IDs: "
                 + ", ".join(
-                    f"ID {record['row_id']} (G2P ID {record['g2p_id']})"
+                    f"lgd_id={record['record_lgd_id']} ({record['deleted_g2p_stable_id']})"
                     for record in invalid_records
                 ),
                 id=error_id,
@@ -50,6 +50,7 @@ def check_deleted_records():
     append_active_records_with_deleted_g2p_ids_error(
         errors,
         LocusGenotypeDisease.objects.filter(stable_id__is_deleted=1, is_deleted=0),
+        "id",
         "stable_id__stable_id",
         "gene2phenotype_app.E701",
     )
@@ -60,6 +61,7 @@ def check_deleted_records():
         LGDMolecularMechanismSynopsis.objects.filter(
             lgd__stable_id__is_deleted=1, is_deleted=0
         ),
+        "lgd__id",
         "lgd__stable_id__stable_id",
         "gene2phenotype_app.E702",
     )
@@ -70,6 +72,7 @@ def check_deleted_records():
         LGDMolecularMechanismEvidence.objects.filter(
             lgd__stable_id__is_deleted=1, is_deleted=0
         ),
+        "lgd__id",
         "lgd__stable_id__stable_id",
         "gene2phenotype_app.E703",
     )
@@ -80,6 +83,7 @@ def check_deleted_records():
         LGDCrossCuttingModifier.objects.filter(
             lgd__stable_id__is_deleted=1, is_deleted=0
         ),
+        "lgd__id",
         "lgd__stable_id__stable_id",
         "gene2phenotype_app.E704",
     )
@@ -88,6 +92,7 @@ def check_deleted_records():
     append_active_records_with_deleted_g2p_ids_error(
         errors,
         LGDPhenotype.objects.filter(lgd__stable_id__is_deleted=1, is_deleted=0),
+        "lgd__id",
         "lgd__stable_id__stable_id",
         "gene2phenotype_app.E705",
     )
@@ -96,6 +101,7 @@ def check_deleted_records():
     append_active_records_with_deleted_g2p_ids_error(
         errors,
         LGDPhenotypeSummary.objects.filter(lgd__stable_id__is_deleted=1, is_deleted=0),
+        "lgd__id",
         "lgd__stable_id__stable_id",
         "gene2phenotype_app.E706",
     )
@@ -104,6 +110,7 @@ def check_deleted_records():
     append_active_records_with_deleted_g2p_ids_error(
         errors,
         LGDVariantType.objects.filter(lgd__stable_id__is_deleted=1, is_deleted=0),
+        "lgd__id",
         "lgd__stable_id__stable_id",
         "gene2phenotype_app.E707",
     )
@@ -114,6 +121,7 @@ def check_deleted_records():
         LGDVariantTypeDescription.objects.filter(
             lgd__stable_id__is_deleted=1, is_deleted=0
         ),
+        "lgd__id",
         "lgd__stable_id__stable_id",
         "gene2phenotype_app.E708",
     )
@@ -124,6 +132,7 @@ def check_deleted_records():
         LGDVariantGenccConsequence.objects.filter(
             lgd__stable_id__is_deleted=1, is_deleted=0
         ),
+        "lgd__id",
         "lgd__stable_id__stable_id",
         "gene2phenotype_app.E709",
     )
@@ -132,6 +141,7 @@ def check_deleted_records():
     append_active_records_with_deleted_g2p_ids_error(
         errors,
         LGDComment.objects.filter(lgd__stable_id__is_deleted=1, is_deleted=0),
+        "lgd__id",
         "lgd__stable_id__stable_id",
         "gene2phenotype_app.E710",
     )
@@ -140,6 +150,7 @@ def check_deleted_records():
     append_active_records_with_deleted_g2p_ids_error(
         errors,
         LGDPublication.objects.filter(lgd__stable_id__is_deleted=1, is_deleted=0),
+        "lgd__id",
         "lgd__stable_id__stable_id",
         "gene2phenotype_app.E711",
     )
@@ -148,6 +159,7 @@ def check_deleted_records():
     append_active_records_with_deleted_g2p_ids_error(
         errors,
         LGDPanel.objects.filter(lgd__stable_id__is_deleted=1, is_deleted=0),
+        "lgd__id",
         "lgd__stable_id__stable_id",
         "gene2phenotype_app.E712",
     )

--- a/gene2phenotype_project/gene2phenotype_app/management/commands/datachecks/__init__.py
+++ b/gene2phenotype_project/gene2phenotype_app/management/commands/datachecks/__init__.py
@@ -15,3 +15,5 @@ from .Disease import (
 from .MinedPublications import check_mined_publication_status
 
 from .SimilarRecords import get_similar_records
+
+from .DeletedRecords import check_deleted_records


### PR DESCRIPTION
### Description ###

Add data check for active LGD-related records linked to deleted G2P IDs.

---

### JIRA Ticket ###

[G2P-71](https://embl.atlassian.net/browse/G2P-71)

---

### Contributor Checklist ###
- [x] The code compiles and runs as expected
- [ ] Relevant unit tests are added or updated
- [ ] All unit tests are passing
- [x] Code follows the [G2P Coding Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51871986/G2P+Coding+Guidelines)
- [x] Documentation (code comments, confluence, etc.) has been updated as needed
