### PR TITLE
Include the panel download response type in OpenAPI

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/views/panel.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/panel.py
@@ -1,9 +1,10 @@
 from rest_framework import generics, status, permissions
+from rest_framework.renderers import BaseRenderer
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from django.http import Http404, HttpResponse
 from django.db.models import Q
-from rest_framework.decorators import api_view
+from rest_framework.decorators import api_view, renderer_classes
 from drf_spectacular.utils import (
     extend_schema,
     OpenApiResponse,
@@ -44,6 +45,16 @@ from gene2phenotype_app.serializers import (
 from .base import BaseAPIView, IsSuperUser, CustomPermissionAPIView
 
 from ..utils import get_date_now
+
+
+class CSVRenderer(BaseRenderer):
+    media_type = "text/csv"
+    format = "csv"
+    charset = "utf-8"
+    render_style = "binary"
+
+    def render(self, data, accepted_media_type=None, renderer_context=None):
+        return data
 
 
 @extend_schema(exclude=True)
@@ -527,6 +538,7 @@ class LGDEditPanel(CustomPermissionAPIView):
     },
 )
 @api_view(["GET"])
+@renderer_classes([CSVRenderer])
 def PanelDownload(request, name):
     """
     Method to download the panel data.

--- a/gene2phenotype_project/gene2phenotype_app/views/panel.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/panel.py
@@ -4,7 +4,12 @@ from rest_framework.response import Response
 from django.http import Http404, HttpResponse
 from django.db.models import Q
 from rest_framework.decorators import api_view
-from drf_spectacular.utils import extend_schema, OpenApiResponse, OpenApiExample
+from drf_spectacular.utils import (
+    extend_schema,
+    OpenApiResponse,
+    OpenApiExample,
+    OpenApiTypes,
+)
 from django.db import transaction
 from django.shortcuts import get_object_or_404
 from datetime import datetime
@@ -514,6 +519,12 @@ class LGDEditPanel(CustomPermissionAPIView):
     - Download DD records:
         `/panel/DD/download`
     """),
+    responses={
+        (200, "text/csv"): OpenApiResponse(
+            response=OpenApiTypes.BINARY,
+            description="Uncompressed CSV export for the selected panel or for all visible panels.",
+        )
+    },
 )
 @api_view(["GET"])
 def PanelDownload(request, name):

--- a/gene2phenotype_project/schema.json
+++ b/gene2phenotype_project/schema.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.3",
     "info": {
         "title": "Gene2Phenotype (G2P)",
-        "version": "15.0.0",
+        "version": "18.0.0",
         "description": "This API enables access to gene disease models held in the G2P database. See [https://www.ebi.ac.uk/gene2phenotype/](https://www.ebi.ac.uk/gene2phenotype/) for more details.<br><br>Contact us by submitting an issue via [https://github.com/EBI-G2P/gene2phenotype_api/issues](https://github.com/EBI-G2P/gene2phenotype_api/issues)."
     },
     "paths": {
@@ -39,6 +39,7 @@
                                 "examples": {
                                     "Example1": {
                                         "value": {
+                                            "summary": "MTFMT-related mitochondrial disease with regression and lactic acidosis has a confidence assertion of definitive based on 5 curated publications. This is a biallelic autosomal condition. Variant consequence is absent gene product (inferred) and altered gene product structure (inferred). Molecular mechanism is loss of function (evidenced by biochemical function, protein expression function, patient cells functional alteration and patient cells rescue). Recorded variant types include splice region variant, frameshift variant, stop gained and missense variant.",
                                             "locus": {
                                                 "gene_symbol": "MTFMT",
                                                 "sequence": "15",
@@ -685,7 +686,15 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "No response body"
+                        "content": {
+                            "text/csv": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "binary"
+                                }
+                            }
+                        },
+                        "description": "Uncompressed CSV export for the selected panel or for all visible panels."
                     }
                 }
             }
@@ -1142,6 +1151,12 @@
                 "type": "object",
                 "description": "Serializer for the LocusGenotypeDisease model.\nLocusGenotypeDisease represents a unique Locus-Genotype-Mechanism-Disease-Evidence (LGMDE) record.",
                 "properties": {
+                    "summary": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "Summary of the LGMDE record.\nThe summary is automatically generated using the record's data.",
+                        "readOnly": true
+                    },
                     "locus": {
                         "type": "object",
                         "additionalProperties": {},
@@ -1312,6 +1327,7 @@
                     "phenotypes",
                     "publications",
                     "stable_id",
+                    "summary",
                     "variant_consequence",
                     "variant_description",
                     "variant_type"


### PR DESCRIPTION
### Description ###

Include the panel download response type in OpenAPI.
This update fixes the warning:
```
?: (drf_spectacular.W002) /builds/EBI-G2P/gene2phenotype_api/gene2phenotype_project/gene2phenotype_app/views/panel.py: Error [PanelDownload]: unable to guess serializer. This is graceful fallback handling for APIViews. Consider using GenericAPIView as view base class, if view is under your control. Either way you may want to add a serializer_class (or method). Ignoring view for now.
```

---

### JIRA Ticket ###

No ticket

---

### Contributor Checklist ###
- [x] The code compiles and runs as expected
- [x] Relevant unit tests are added or updated
- [x] All unit tests are passing
- [x] Code follows the [G2P Coding Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51871986/G2P+Coding+Guidelines)
- [x] Documentation (code comments, confluence, etc.) has been updated as needed
