### PR TITLE
Improve endpoint to add/delete variant types

### DIFF
--- a/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
@@ -1564,6 +1564,15 @@ class LGDVariantTypeSerializer(serializers.ModelSerializer):
         write_only=True, allow_blank=True
     )  # single comment (used by curation)
 
+    @staticmethod
+    def _apply_latest_inheritance_flags(
+        lgd_variant_type_obj, inherited, de_novo, unknown_inheritance
+    ):
+        lgd_variant_type_obj.inherited = inherited
+        lgd_variant_type_obj.de_novo = de_novo
+        lgd_variant_type_obj.unknown_inheritance = unknown_inheritance
+        return lgd_variant_type_obj
+
     def create(self, validated_data):
         """
         Method to create LGDVariantType object.
@@ -1614,16 +1623,12 @@ class LGDVariantTypeSerializer(serializers.ModelSerializer):
                 # if deleted, set to not deleted
                 if lgd_variant_type_obj.is_deleted == 1:
                     lgd_variant_type_obj.is_deleted = 0
-                # update inheritance data
-                if lgd_variant_type_obj.inherited == 0 and inherited is True:
-                    lgd_variant_type_obj.inherited = 1
-                if lgd_variant_type_obj.de_novo == 0 and de_novo is True:
-                    lgd_variant_type_obj.de_novo = 1
-                if (
-                    lgd_variant_type_obj.unknown_inheritance == 0
-                    and unknown_inheritance is True
-                ):
-                    lgd_variant_type_obj.unknown_inheritance = 1
+                self._apply_latest_inheritance_flags(
+                    lgd_variant_type_obj,
+                    inherited,
+                    de_novo,
+                    unknown_inheritance,
+                )
                 lgd_variant_type_obj.save()
 
             # The LGDPhenotypeSummary is created - next step is to create the LGDVariantTypeComment
@@ -1698,40 +1703,24 @@ class LGDVariantTypeSerializer(serializers.ModelSerializer):
                             # LGDVariantType already exists in the db without a publication
                             # Add publication to existing object
                             lgd_variant_type_obj.publication = publication_obj
-                            if (
-                                lgd_variant_type_obj.inherited is False
-                                and inherited is True
-                            ):
-                                lgd_variant_type_obj.inherited = True
-                            if (
-                                lgd_variant_type_obj.de_novo is False
-                                and de_novo is True
-                            ):
-                                lgd_variant_type_obj.de_novo = True
-                            if (
-                                lgd_variant_type_obj.unknown_inheritance is False
-                                and unknown_inheritance is True
-                            ):
-                                lgd_variant_type_obj.unknown_inheritance = True
+                            self._apply_latest_inheritance_flags(
+                                lgd_variant_type_obj,
+                                inherited,
+                                de_novo,
+                                unknown_inheritance,
+                            )
                             lgd_variant_type_obj.save()
                     else:
                         # the entry already exists, it probably needs to be updated
                         # if deleted, set to not deleted
                         if lgd_variant_type_obj.is_deleted == 1:
                             lgd_variant_type_obj.is_deleted = 0
-                        # update inheritance data
-                        if (
-                            lgd_variant_type_obj.inherited is False
-                            and inherited is True
-                        ):
-                            lgd_variant_type_obj.inherited = True
-                        if lgd_variant_type_obj.de_novo is False and de_novo is True:
-                            lgd_variant_type_obj.de_novo = True
-                        if (
-                            lgd_variant_type_obj.unknown_inheritance is False
-                            and unknown_inheritance is True
-                        ):
-                            lgd_variant_type_obj.unknown_inheritance = True
+                        self._apply_latest_inheritance_flags(
+                            lgd_variant_type_obj,
+                            inherited,
+                            de_novo,
+                            unknown_inheritance,
+                        )
                         lgd_variant_type_obj.save()
 
                     # The LGDPhenotypeSummary is created - next step is to create the LGDVariantTypeComment

--- a/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/serializers/locus_genotype_disease.py
@@ -464,16 +464,18 @@ class LocusGenotypeDiseaseSerializer(serializers.ModelSerializer):
                 date = None
                 if comment_obj.date is not None:
                     date = comment_obj.date.strftime("%Y-%m-%d")
+                comment_data = {
+                    "id": comment_obj.id,
+                    "text": comment_text,
+                    "date": date,
+                }
 
                 if accession not in list_of_comments:
-                    list_of_comments[accession] = [{"text": comment_text, "date": date}]
+                    list_of_comments[accession] = [comment_data]
                 elif not any(
-                    comment["text"] == comment_text
-                    for comment in list_of_comments[accession]
+                    comment["id"] == comment_obj.id for comment in list_of_comments[accession]
                 ):
-                    list_of_comments[accession].append(
-                        {"text": comment_text, "date": date}
-                    )
+                    list_of_comments[accession].append(comment_data)
 
             if accession in data and lgd_variant.publication:
                 variant_type_comments = []
@@ -1521,13 +1523,14 @@ class LGDVariantTypeCommentSerializer(serializers.ModelSerializer):
     by curators.
     """
 
+    id = serializers.IntegerField(read_only=True)
     comment = serializers.CharField()
     user = serializers.CharField(source="user.username")
     date = serializers.CharField()
 
     class Meta:
         model = LGDVariantTypeComment
-        fields = ["comment", "user", "date"]
+        fields = ["id", "comment", "user", "date"]
 
 
 class LGDVariantTypeSerializer(serializers.ModelSerializer):

--- a/gene2phenotype_project/gene2phenotype_app/tests/insert_data/test_add_variant_types.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/insert_data/test_add_variant_types.py
@@ -7,6 +7,7 @@ from gene2phenotype_app.models import (
     User,
     LGDVariantType,
     LocusGenotypeDisease,
+    OntologyTerm,
 )
 
 
@@ -214,3 +215,99 @@ class LGDEditVariantTypesTests(TestCase):
 
         lgd_obj = LocusGenotypeDisease.objects.get(stable_id__stable_id="G2P00002")
         self.assertEqual(lgd_obj.date_review, self.original_date_review)
+
+    def test_readd_soft_deleted_variant_updates_inheritance_flags(self):
+        """
+        Test that re-adding a soft-deleted variant type restores the row and
+        replaces inheritance flags with the latest payload values.
+        """
+        user = User.objects.get(email="john@test.ac.uk")
+        refresh = RefreshToken.for_user(user)
+        access_token = str(refresh.access_token)
+        self.client.cookies[settings.SIMPLE_JWT["AUTH_COOKIE"]] = access_token
+
+        missense_variant = OntologyTerm.objects.get(term="missense_variant")
+        lgd_variant = LGDVariantType.objects.create(
+            lgd=LocusGenotypeDisease.objects.get(stable_id__stable_id="G2P00002"),
+            variant_type_ot=missense_variant,
+            inherited=True,
+            de_novo=True,
+            unknown_inheritance=True,
+            publication_id=3,
+            is_deleted=1,
+        )
+
+        payload = {
+            "variant_types": [
+                {
+                    "comment": "",
+                    "de_novo": False,
+                    "inherited": False,
+                    "primary_type": "protein_changing",
+                    "secondary_type": "missense_variant",
+                    "supporting_papers": ["12451214"],
+                    "unknown_inheritance": False,
+                }
+            ]
+        }
+
+        response = self.client.post(
+            self.url_add_variant,
+            payload,
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 201)
+
+        lgd_variant.refresh_from_db()
+        self.assertEqual(lgd_variant.is_deleted, 0)
+        self.assertFalse(lgd_variant.inherited)
+        self.assertFalse(lgd_variant.de_novo)
+        self.assertFalse(lgd_variant.unknown_inheritance)
+
+    def test_reuse_existing_row_with_new_publication_updates_inheritance_flags(self):
+        """
+        Test that converting an existing publication-less row into a
+        publication-linked row replaces inheritance flags with the latest payload.
+        """
+        user = User.objects.get(email="john@test.ac.uk")
+        refresh = RefreshToken.for_user(user)
+        access_token = str(refresh.access_token)
+        self.client.cookies[settings.SIMPLE_JWT["AUTH_COOKIE"]] = access_token
+
+        missense_variant = OntologyTerm.objects.get(term="missense_variant")
+        lgd_variant = LGDVariantType.objects.create(
+            lgd=LocusGenotypeDisease.objects.get(stable_id__stable_id="G2P00002"),
+            variant_type_ot=missense_variant,
+            inherited=True,
+            de_novo=True,
+            unknown_inheritance=True,
+            publication=None,
+            is_deleted=0,
+        )
+
+        payload = {
+            "variant_types": [
+                {
+                    "comment": "",
+                    "de_novo": False,
+                    "inherited": False,
+                    "primary_type": "protein_changing",
+                    "secondary_type": "missense_variant",
+                    "supporting_papers": ["12451214"],
+                    "unknown_inheritance": False,
+                }
+            ]
+        }
+
+        response = self.client.post(
+            self.url_add_variant,
+            payload,
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 201)
+
+        lgd_variant.refresh_from_db()
+        self.assertEqual(lgd_variant.publication_id, 3)
+        self.assertFalse(lgd_variant.inherited)
+        self.assertFalse(lgd_variant.de_novo)
+        self.assertFalse(lgd_variant.unknown_inheritance)

--- a/gene2phenotype_project/gene2phenotype_app/tests/insert_data/test_add_variant_types.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/insert_data/test_add_variant_types.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from django.urls import reverse
 from django.conf import settings
+from datetime import datetime
 from rest_framework_simplejwt.tokens import RefreshToken
 from gene2phenotype_app.models import (
     User,
@@ -37,6 +38,9 @@ class LGDEditVariantTypesTests(TestCase):
         self.url_add_variant = reverse(
             "lgd_variant_type", kwargs={"stable_id": "G2P00002"}
         )
+        self.original_date_review = LocusGenotypeDisease.objects.get(
+            stable_id__stable_id="G2P00002"
+        ).date_review
         self.variant_to_add = {
             "variant_types": [
                 {
@@ -157,3 +161,56 @@ class LGDEditVariantTypesTests(TestCase):
             response_data["error"],
             "Empty variant type. Please provide valid data.",
         )
+        lgd_obj = LocusGenotypeDisease.objects.get(stable_id__stable_id="G2P00002")
+        self.assertEqual(lgd_obj.date_review, self.original_date_review)
+
+    def test_add_variant_types_is_atomic(self):
+        """
+        Test that the endpoint validates the full payload before saving data.
+        """
+        user = User.objects.get(email="john@test.ac.uk")
+        refresh = RefreshToken.for_user(user)
+        access_token = str(refresh.access_token)
+        self.client.cookies[settings.SIMPLE_JWT["AUTH_COOKIE"]] = access_token
+
+        payload = {
+            "variant_types": [
+                {
+                    "comment": "valid comment",
+                    "de_novo": False,
+                    "inherited": True,
+                    "primary_type": "protein_changing",
+                    "secondary_type": "stop_gained",
+                    "supporting_papers": ["12451214"],
+                    "unknown_inheritance": True,
+                },
+                {
+                    "comment": "invalid comment",
+                    "de_novo": False,
+                    "inherited": True,
+                    "primary_type": "protein_changing",
+                    "secondary_type": "not_a_real_variant_type",
+                    "supporting_papers": ["12451214"],
+                    "unknown_inheritance": True,
+                },
+            ]
+        }
+
+        response = self.client.post(
+            self.url_add_variant,
+            payload,
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("not_a_real_variant_type", str(response.json()["error"]))
+
+        lgd_variants = LGDVariantType.objects.filter(
+            lgd__stable_id__stable_id="G2P00002", is_deleted=0
+        )
+        self.assertEqual(len(lgd_variants), 2)
+
+        history_records = LGDVariantType.history.all()
+        self.assertEqual(len(history_records), 0)
+
+        lgd_obj = LocusGenotypeDisease.objects.get(stable_id__stable_id="G2P00002")
+        self.assertEqual(lgd_obj.date_review, self.original_date_review)

--- a/gene2phenotype_project/gene2phenotype_app/tests/views/test_locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/tests/views/test_locus_genotype_disease.py
@@ -33,6 +33,8 @@ class LocusGenotypeDiseaseDetailEndpoint(TestCase):
         "gene2phenotype_app/fixtures/lgd_publication_comment.json",
         "gene2phenotype_app/fixtures/mined_publication.json",
         "gene2phenotype_app/fixtures/lgd_mined_publication.json",
+        "gene2phenotype_app/fixtures/lgd_variant_type.json",
+        "gene2phenotype_app/fixtures/lgd_variant_type_comment.json",
     ]
 
     def setUp(self):
@@ -315,4 +317,32 @@ class LocusGenotypeDiseaseDetailEndpoint(TestCase):
         ]
         self.assertEqual(
             list(response.data["phenotype_summary"]), expected_phenotype_summary
+        )
+
+    def test_lgd_detail_authenticated_variant_type_comments_include_id(self):
+        """
+        Test authenticated LGD detail includes variant type comment IDs.
+        """
+        user = User.objects.get(email="user5@test.ac.uk")
+        refresh = RefreshToken.for_user(user)
+        access_token = str(refresh.access_token)
+        self.client.cookies[settings.SIMPLE_JWT["AUTH_COOKIE"]] = access_token
+
+        response = self.client.get(self.url_list_lgd_2)
+        self.assertEqual(response.status_code, 200)
+
+        inframe_insertion = next(
+            variant
+            for variant in response.data["variant_type"]
+            if variant["term"] == "inframe_insertion"
+        )
+        self.assertEqual(
+            inframe_insertion["comments"],
+            [
+                {
+                    "id": 1,
+                    "text": "Recurrent c.340C>T; p.Arg114Ter in 5/9 cases.",
+                    "date": "2025-02-19",
+                }
+            ],
         )

--- a/gene2phenotype_project/gene2phenotype_app/views/locus_genotype_disease.py
+++ b/gene2phenotype_project/gene2phenotype_app/views/locus_genotype_disease.py
@@ -1153,7 +1153,6 @@ class LGDEditVariantTypes(CustomPermissionAPIView):
                 }
         """
         user = self.request.user  # email
-        success_flag = 0
 
         lgd = get_object_or_404(
             LocusGenotypeDisease, stable_id__stable_id=stable_id, is_deleted=0
@@ -1185,36 +1184,37 @@ class LGDEditVariantTypes(CustomPermissionAPIView):
                     status=status.HTTP_400_BAD_REQUEST,
                 )
 
-            # Add each variant GenCC consequence from the input list
+            validated_serializers = []
+
+            # Validate the full payload before saving any changes
             for var_type in variant_type_data:
-                # The data is created in LGDVariantTypeSerializer
                 serializer_class = LGDVariantTypeSerializer(
                     data=var_type, context={"lgd": lgd, "user": user_obj}
                 )
 
-                if serializer_class.is_valid():
-                    serializer_class.save()
-                    success_flag = 1
-                    response = Response(
-                        {
-                            "message": "Variant type added to the G2P entry successfully."
-                        },
-                        status=status.HTTP_201_CREATED,
-                    )
-                else:
-                    response = Response(
+                if not serializer_class.is_valid():
+                    return Response(
                         {"error": serializer_class.errors},
                         status=status.HTTP_400_BAD_REQUEST,
                     )
+
+                validated_serializers.append(serializer_class)
+
+            for serializer_class in validated_serializers:
+                serializer_class.save()
+
+            lgd.date_review = get_date_now()
+            lgd.save_without_historical_record()
+
+            response = Response(
+                {"message": "Variant type added to the G2P entry successfully."},
+                status=status.HTTP_201_CREATED,
+            )
 
         else:
             response = Response(
                 {"error": serializer_list.errors}, status=status.HTTP_400_BAD_REQUEST
             )
-
-        # Update the record date_review, if at least one variant type was added successfully
-        lgd.date_review = get_date_now()
-        lgd.save_without_historical_record()
 
         return response
 


### PR DESCRIPTION
### Description ###

Updates:
- Improve the code that add/deletes variant types
- Update API to allow fixing existing variant types (inherited, de novo, unknown inheritance flags)
- Include the variant type comment id in the response (example: gene2phenotype/api/lgd/G2P03720/) -> necessary to correctly delete comments

---

### JIRA Ticket ###

[G2P-759](https://embl.atlassian.net/browse/G2P-759)


---

### Contributor Checklist ###
- [x] The code compiles and runs as expected
- [x] Relevant unit tests are added or updated
- [x] All unit tests are passing
- [x] Code follows the [G2P Coding Guidelines](https://embl.atlassian.net/wiki/spaces/EBIMedical/pages/51871986/G2P+Coding+Guidelines)
- [x] Documentation (code comments, confluence, etc.) has been updated as needed
